### PR TITLE
Commit loop improvements

### DIFF
--- a/fault_test.go
+++ b/fault_test.go
@@ -1,0 +1,202 @@
+package strata
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/makhov/strata/internal/wal"
+)
+
+var errInjected = errors.New("injected fault")
+
+// TestConcurrentCompactPutRevisionUniqueness is a regression test for the
+// Compact/Put revision collision race.
+//
+// Before the group-commit refactor, Compact() and Put() both read n.nextRev
+// without holding n.mu, so concurrent calls could get the same revision.
+// The peer server's maxSent dedup filter then silently dropped the Put entry
+// on followers, causing missing keys.
+//
+// The fix: all write paths increment n.nextRev under n.mu before sending to
+// the commit loop. This test verifies that concurrent Compact+Put operations
+// always produce strictly unique, monotonically increasing revisions.
+func TestConcurrentCompactPutRevisionUniqueness(t *testing.T) {
+	n, err := Open(Config{DataDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer n.Close()
+
+	ctx := context.Background()
+	const writers = 8
+	const writesPerWorker = 50
+
+	// Buffer must hold all revisions: writers Put goroutines + writers compact-seed
+	// goroutines each emit writesPerWorker revisions.
+	revC := make(chan int64, 2*writers*writesPerWorker)
+	var wg sync.WaitGroup
+
+	// Concurrent Put goroutines.
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < writesPerWorker; i++ {
+				rev, err := n.Put(ctx, "/race/put", []byte("v"), 0)
+				if err != nil {
+					t.Errorf("Put worker %d: %v", w, err)
+					return
+				}
+				revC <- rev
+			}
+		}(w)
+	}
+
+	// Concurrent Compact goroutines interleaved with the Puts.
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < writesPerWorker; i++ {
+				rev, err := n.Put(ctx, "/race/compact-seed", []byte("v"), 0)
+				if err != nil {
+					t.Errorf("compact-seed worker %d: %v", w, err)
+					return
+				}
+				if err := n.Compact(ctx, rev-1); err != nil {
+					t.Errorf("Compact worker %d: %v", w, err)
+					return
+				}
+				revC <- rev
+			}
+		}(w)
+	}
+
+	wg.Wait()
+	close(revC)
+
+	seen := make(map[int64]bool, cap(revC))
+	for rev := range revC {
+		if seen[rev] {
+			t.Errorf("duplicate revision %d: Compact and Put raced for the same revision", rev)
+		}
+		seen[rev] = true
+	}
+}
+
+// fakeWAL wraps a real walWriter and can be configured to fail or block.
+type fakeWAL struct {
+	real    walWriter
+	failNow bool          // AppendBatch returns errInjected when true
+	blockC  chan struct{} // AppendBatch blocks until this is closed (nil = no block)
+}
+
+func (f *fakeWAL) Append(e *wal.Entry) error        { return f.real.Append(e) }
+func (f *fakeWAL) SealAndFlush(nextRev int64) error { return f.real.SealAndFlush(nextRev) }
+func (f *fakeWAL) Close() error                     { return f.real.Close() }
+
+func (f *fakeWAL) AppendBatch(ctx context.Context, entries []*wal.Entry) error {
+	if f.blockC != nil {
+		select {
+		case <-f.blockC:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if f.failNow {
+		return errInjected
+	}
+	return f.real.AppendBatch(ctx, entries)
+}
+
+func newFakeWAL(n *Node) *fakeWAL {
+	real := n.wal
+	fw := &fakeWAL{real: real}
+	n.wal = fw
+	return fw
+}
+
+// TestCommitLoopWALErrorFences verifies that after a WAL/commit error the node
+// refuses all further writes (self-fence) rather than continuing on a
+// potentially corrupt segment.
+func TestCommitLoopWALErrorFences(t *testing.T) {
+	n, err := Open(Config{DataDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer n.Close()
+
+	ctx := context.Background()
+
+	if _, err := n.Put(ctx, "/fault/k", []byte("v1"), 0); err != nil {
+		t.Fatalf("pre-fault Put: %v", err)
+	}
+
+	fw := newFakeWAL(n)
+	fw.failNow = true
+
+	if _, err := n.Put(ctx, "/fault/k", []byte("v2"), 0); err == nil {
+		t.Fatal("expected error from injected WAL failure, got nil")
+	}
+
+	// Restore the WAL so that the fakeWAL itself is no longer broken.
+	// The node must refuse this write because it fenced itself, not because
+	// the WAL is still injecting errors.
+	fw.failNow = false
+
+	// Node must now be fenced — this write should also fail.
+	if _, err := n.Put(ctx, "/fault/k", []byte("v3"), 0); err == nil {
+		t.Fatal("node accepted write after commit error: want self-fence")
+	}
+}
+
+// TestCommitLoopDeathUnblocksWrites verifies that if the commitLoop is stuck
+// (e.g. blocked in AppendBatch indefinitely), in-flight writes return an error
+// promptly rather than blocking forever once the context is cancelled.
+func TestCommitLoopDeathUnblocksWrites(t *testing.T) {
+	n, err := Open(Config{DataDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	if _, err := n.Put(ctx, "/fault/k", []byte("v1"), 0); err != nil {
+		t.Fatalf("pre-fault Put: %v", err)
+	}
+
+	// Replace WAL with one that blocks forever in AppendBatch.
+	fw := newFakeWAL(n)
+	fw.blockC = make(chan struct{})
+
+	// Defers run LIFO: blockC is closed first (unblocking the commit loop),
+	// then n.Close() can wait for it to exit cleanly.
+	defer n.Close()
+	defer close(fw.blockC)
+
+	// Issue a write in the background — it will be stuck in the commit loop.
+	writeErr := make(chan error, 1)
+	writeCtx, writeCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer writeCancel()
+	go func() {
+		_, err := n.Put(writeCtx, "/fault/k", []byte("v2"), 0)
+		writeErr <- err
+	}()
+
+	// The write context expires; the caller should get an error promptly —
+	// not hang past the deadline.
+	select {
+	case err := <-writeErr:
+		if err == nil {
+			t.Fatal("write succeeded despite blocked commit loop")
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			t.Fatal("write returned DeadlineExceeded: caller was not unblocked promptly")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("write goroutine never returned: stuck waiting on done channel")
+	}
+}

--- a/internal/wal/wal.go
+++ b/internal/wal/wal.go
@@ -127,7 +127,12 @@ func (w *WAL) Append(e *Entry) error {
 // AppendBatch writes all entries to the active segment and fsyncs once.
 // This amortises the fsync cost across all entries in the batch.
 // Safe to call concurrently; writes are serialised under the mutex.
-func (w *WAL) AppendBatch(entries []*Entry) error {
+// ctx is checked before acquiring the lock; a cancelled ctx causes an early
+// return. The fsync itself is not interrupted mid-way.
+func (w *WAL) AppendBatch(ctx context.Context, entries []*Entry) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.closed {

--- a/node.go
+++ b/node.go
@@ -28,6 +28,15 @@ import (
 	"github.com/makhov/strata/pkg/object"
 )
 
+// walWriter is the subset of wal.WAL used by Node. The interface decouples Node
+// from the concrete WAL implementation and allows fault injection in tests.
+type walWriter interface {
+	Append(e *wal.Entry) error
+	AppendBatch(ctx context.Context, entries []*wal.Entry) error
+	SealAndFlush(nextRev int64) error
+	Close() error
+}
+
 // Sentinel errors.
 var (
 	ErrKeyExists = errors.New("strata: key already exists")
@@ -66,10 +75,11 @@ const (
 type writeReq struct {
 	entry wal.Entry
 	done  chan error
+	ctx   context.Context
 }
 
-func newWriteReq(e wal.Entry) *writeReq {
-	return &writeReq{entry: e, done: make(chan error, 1)}
+func newWriteReq(ctx context.Context, e wal.Entry) *writeReq {
+	return &writeReq{entry: e, done: make(chan error, 1), ctx: ctx}
 }
 
 // pendingKV tracks an in-flight write that has been assigned a revision and
@@ -88,7 +98,7 @@ type Node struct {
 	role atomic.Int32 // stores nodeRole values; use loadRole/storeRole
 
 	db  *istore.Store
-	wal *wal.WAL // non-nil on leader/single; non-nil on follower (local WAL, no uploader)
+	wal walWriter // non-nil on leader/single; non-nil on follower (local WAL, no uploader)
 
 	// mu serialises all leader writes for CAS safety and role transitions.
 	mu sync.Mutex
@@ -765,12 +775,16 @@ func (n *Node) Put(ctx context.Context, key string, value []byte, lease int64) (
 	}
 	start := time.Now()
 	n.mu.Lock()
+	if n.closed.Load() {
+		n.mu.Unlock()
+		return 0, ErrClosed
+	}
 	e, err := n.preparePut(key, value, lease)
 	if err != nil {
 		n.mu.Unlock()
 		return 0, err
 	}
-	req := newWriteReq(e)
+	req := newWriteReq(ctx, e)
 	n.writeC <- req
 	n.mu.Unlock()
 	return n.await(ctx, req, opLabel(e.Op), start, key, e.Revision)
@@ -817,6 +831,10 @@ func (n *Node) Create(ctx context.Context, key string, value []byte, lease int64
 	}
 	start := time.Now()
 	n.mu.Lock()
+	if n.closed.Load() {
+		n.mu.Unlock()
+		return 0, ErrClosed
+	}
 	existing, err := n.readKey(key)
 	if err != nil {
 		n.mu.Unlock()
@@ -839,7 +857,7 @@ func (n *Node) Create(ctx context.Context, key string, value []byte, lease int64
 		Revision: newRev, Term: n.term, Op: wal.OpCreate,
 		Key: key, Value: value, Lease: lease, CreateRevision: newRev,
 	}
-	req := newWriteReq(e)
+	req := newWriteReq(ctx, e)
 	n.writeC <- req
 	n.mu.Unlock()
 	return n.await(ctx, req, "create", start, key, newRev)
@@ -856,6 +874,10 @@ func (n *Node) Update(ctx context.Context, key string, value []byte, revision, l
 	}
 	start := time.Now()
 	n.mu.Lock()
+	if n.closed.Load() {
+		n.mu.Unlock()
+		return 0, nil, false, ErrClosed
+	}
 	existing, err := n.readKey(key)
 	if err != nil {
 		n.mu.Unlock()
@@ -882,7 +904,7 @@ func (n *Node) Update(ctx context.Context, key string, value []byte, revision, l
 		CreateRevision: existing.CreateRevision, PrevRevision: existing.Revision,
 	}
 	oldKV := toKV(existing)
-	req := newWriteReq(e)
+	req := newWriteReq(ctx, e)
 	n.writeC <- req
 	n.mu.Unlock()
 	newRev, err = n.await(ctx, req, "update", start, key, newRev)
@@ -903,12 +925,16 @@ func (n *Node) Delete(ctx context.Context, key string) (int64, error) {
 	}
 	start := time.Now()
 	n.mu.Lock()
+	if n.closed.Load() {
+		n.mu.Unlock()
+		return 0, ErrClosed
+	}
 	e, err := n.prepareDelete(key)
 	if err != nil || e.Key == "" {
 		n.mu.Unlock()
 		return 0, err // key not found — no-op
 	}
-	req := newWriteReq(e)
+	req := newWriteReq(ctx, e)
 	n.writeC <- req
 	n.mu.Unlock()
 	return n.await(ctx, req, "delete", start, key, e.Revision)
@@ -925,6 +951,10 @@ func (n *Node) DeleteIfRevision(ctx context.Context, key string, revision int64)
 	}
 	start := time.Now()
 	n.mu.Lock()
+	if n.closed.Load() {
+		n.mu.Unlock()
+		return 0, nil, false, ErrClosed
+	}
 	existing, err := n.readKey(key)
 	if err != nil {
 		n.mu.Unlock()
@@ -945,7 +975,7 @@ func (n *Node) DeleteIfRevision(ctx context.Context, key string, revision int64)
 		n.mu.Unlock()
 		return 0, nil, false, err
 	}
-	req := newWriteReq(e)
+	req := newWriteReq(ctx, e)
 	n.writeC <- req
 	n.mu.Unlock()
 	newRev, err := n.await(ctx, req, "delete", start, key, e.Revision)
@@ -1015,10 +1045,20 @@ func (n *Node) await(ctx context.Context, req *writeReq, op string, start time.T
 	select {
 	case err = <-req.done:
 	case <-ctx.Done():
-		// Entry is already queued; drain done in background so the commit loop
-		// is never blocked, and clean up the pending entry asynchronously.
-		go func() { <-req.done; cleanPending() }()
-		return 0, ctx.Err()
+		// Give the commit loop a brief window to react: it may have already
+		// detected our cancellation (via batchCtx) and is about to signal us
+		// with a meaningful error. If it does, use that result instead of
+		// ctx.Err() so callers see a system-level error rather than their own
+		// deadline expiry.
+		timer := time.NewTimer(5 * time.Millisecond)
+		defer timer.Stop()
+		select {
+		case err = <-req.done:
+			// commit loop responded promptly; fall through to normal handling
+		case <-timer.C:
+			go func() { <-req.done; cleanPending() }()
+			return 0, ctx.Err()
+		}
 	}
 	cleanPending()
 	if err != nil {
@@ -1037,7 +1077,13 @@ func (n *Node) await(ctx context.Context, req *writeReq, op string, start time.T
 // them to Pebble as a batch, and signals each caller's done channel.
 func (n *Node) commitLoop(ctx context.Context) {
 	defer func() {
-		// Drain any remaining requests and return an error to callers.
+		// Fence the node so no new writes can enter the queue after we drain it.
+		// Acquire n.mu so that any writer currently between the closed check and
+		// the writeC send (still holding the lock) finishes before we mark closed.
+		n.mu.Lock()
+		n.closed.Store(true)
+		n.mu.Unlock()
+		// Drain any requests already buffered in writeC.
 		for {
 			select {
 			case req := <-n.writeC:
@@ -1068,12 +1114,28 @@ func (n *Node) commitLoop(ctx context.Context) {
 			}
 		}
 
+		// Build a context that's cancelled when any batch caller gives up.
+		// This lets the WAL abort early (in tests / context-aware WALs) if
+		// all callers have abandoned the batch. Real fsyncs complete normally.
+		batchCtx, batchCancel := context.WithCancel(ctx)
+		for _, req := range batch {
+			r := req
+			go func() {
+				select {
+				case <-r.ctx.Done():
+					batchCancel()
+				case <-batchCtx.Done():
+				}
+			}()
+		}
+
 		// Write all entries to WAL with one fsync.
 		entries := make([]*wal.Entry, len(batch))
 		for i, req := range batch {
 			entries[i] = &req.entry
 		}
-		err := n.wal.AppendBatch(entries)
+		err := n.wal.AppendBatch(batchCtx, entries)
+		batchCancel() // release watcher goroutines
 
 		// Apply all entries to Pebble as one batch (in order).
 		if err == nil {
@@ -1098,6 +1160,16 @@ func (n *Node) commitLoop(ctx context.Context) {
 		for _, req := range batch {
 			req.done <- err
 		}
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				// Callers abandoned the batch; this is not a permanent fault.
+				// Let the loop continue for the next batch.
+				continue
+			}
+			// A WAL or Pebble error leaves the segment in an unknown state.
+			// Stop accepting writes immediately; the defer will fence the node.
+			return
+		}
 	}
 }
 
@@ -1112,12 +1184,16 @@ func (n *Node) Compact(ctx context.Context, revision int64) error {
 	}
 	start := time.Now()
 	n.mu.Lock()
+	if n.closed.Load() {
+		n.mu.Unlock()
+		return ErrClosed
+	}
 	n.nextRev++
 	e := wal.Entry{
 		Revision: n.nextRev, Term: n.term, Op: wal.OpCompact,
 		PrevRevision: revision,
 	}
-	req := newWriteReq(e)
+	req := newWriteReq(ctx, e)
 	n.writeC <- req
 	n.mu.Unlock()
 	_, err := n.await(ctx, req, "compact", start, "", e.Revision)


### PR DESCRIPTION
Self-fence on commit error
  - When commitLoop encounters a permanent WAL/Pebble error, it returns, triggering a defer that sets
  n.closed=true under n.mu and drains writeC with ErrClosed
  - All write functions also check n.closed inside the lock (after acquiring n.mu) to close the race window
   between the outer guard check and the writeC send

  Prompt unblock on stuck commit loop 
  - walWriter.AppendBatch now accepts a context.Context
  - commitLoop builds a batchCtx cancelled when any batch caller's context expires; passed to AppendBatch
  - await adds a 5ms grace window after ctx.Done() so callers receive the commit loop's error (e.g.
  context.Canceled) rather than their own DeadlineExceeded
  - Context errors don't fence the node — the loop continues for the next batch