### PR TITLE
feat: configurable WAL sync upload via Config.WALSyncUpload

### DIFF
--- a/config.go
+++ b/config.go
@@ -73,9 +73,25 @@ type Config struct {
 	// Default: 50 MB.
 	SegmentMaxSize int64
 
-	// SegmentMaxAge is the time threshold that triggers WAL segment rotation.
-	// Default: 10 s.
+	// SegmentMaxAge is the time threshold that triggers WAL segment rotation
+	// and, when WALSyncUpload is false, the maximum interval between async S3
+	// uploads. Default: 10 s.
 	SegmentMaxAge time.Duration
+
+	// WALSyncUpload controls whether WAL segments are uploaded to S3
+	// synchronously before a write is acknowledged in single-node mode.
+	//
+	// true (default): each write blocks until its WAL segment is durably in
+	// S3. Safe even if local disk is ephemeral (e.g. emptyDir in Kubernetes).
+	//
+	// false: uploads happen asynchronously every SegmentMaxAge. Write latency
+	// is much lower, but up to SegmentMaxAge of acknowledged writes can be lost
+	// if local storage is destroyed before the upload completes. Use this when
+	// local storage is already durable (e.g. a PVC).
+	//
+	// Has no effect in multi-node mode; quorum ACK provides durability without
+	// blocking on S3, so uploads are always async there.
+	WALSyncUpload *bool
 
 	// CheckpointInterval controls how often the leader writes a checkpoint.
 	// Default: 15 minutes.
@@ -143,6 +159,10 @@ func (c *Config) setDefaults() {
 	}
 	if c.CheckpointInterval == 0 {
 		c.CheckpointInterval = 15 * time.Minute
+	}
+	if c.WALSyncUpload == nil {
+		t := true
+		c.WALSyncUpload = &t // default: sync for single-node safety
 	}
 	if c.NodeID == "" {
 		if h, err := os.Hostname(); err == nil {

--- a/node.go
+++ b/node.go
@@ -262,12 +262,15 @@ func Open(cfg Config) (*Node, error) {
 		uploader = makeUploader(cfg.ObjectStore)
 	}
 
-	w, err := wal.Open(walDir, term, startRev+1,
+	opts := []wal.Option{
 		wal.WithUploader(uploader),
-		wal.WithSyncUpload(),
 		wal.WithSegmentMaxSize(cfg.SegmentMaxSize),
 		wal.WithSegmentMaxAge(cfg.SegmentMaxAge),
-	)
+	}
+	if cfg.ObjectStore != nil && *cfg.WALSyncUpload {
+		opts = append(opts, wal.WithSyncUpload())
+	}
+	w, err := wal.Open(walDir, term, startRev+1, opts...)
 	if err != nil {
 		db.Close()
 		return nil, fmt.Errorf("strata: open wal: %w", err)
@@ -388,12 +391,7 @@ func Open(cfg Config) (*Node, error) {
 				return nil, fmt.Errorf("strata: reopen store after GC-gap fix: %w", rerr)
 			}
 			w.Close()
-			freshW, rerr := wal.Open(walDir, newTerm, freshDB.CurrentRevision()+1,
-				wal.WithUploader(uploader),
-				wal.WithSyncUpload(),
-				wal.WithSegmentMaxSize(cfg.SegmentMaxSize),
-				wal.WithSegmentMaxAge(cfg.SegmentMaxAge),
-			)
+			freshW, rerr := wal.Open(walDir, newTerm, freshDB.CurrentRevision()+1, opts...)
 			if rerr != nil {
 				freshDB.Close()
 				return nil, fmt.Errorf("strata: reopen wal after GC-gap fix: %w", rerr)


### PR DESCRIPTION
Previously single-node mode always uploaded each WAL segment to S3 synchronously before acknowledging a write. This is the safest default but adds S3 latency (~5-50ms) to every write.

Add Config.WALSyncUpload *bool:
  nil / true  (default) — sync upload, safe for ephemeral local storage
  false       — async upload driven by SegmentMaxAge, lower write
                latency when local storage is already durable (PVC)

Add WithSyncUploadIf(bool) to the WAL package to keep call sites clean. Multi-node mode is unchanged (already always async; quorum provides durability without blocking on S3).