### PR TITLE
Custom GRPC codec and message batching

### DIFF
--- a/internal/peer/client.go
+++ b/internal/peer/client.go
@@ -82,14 +82,16 @@ func (c *Client) getConn() (*grpc.ClientConn, error) {
 }
 
 // Follow streams WAL entries from the leader starting at fromRev, calling
-// applyFn for each entry. fromRev advances automatically as entries are applied.
+// applyFn for each batch of entries. fromRev advances automatically as entries
+// are applied. Batches contain all entries that arrived between consecutive
+// applyFn calls, amortising WAL fsyncs across multiple revisions.
 //
 // Follow reconnects on transient errors. It returns:
 //   - ctx.Err() on context cancellation.
 //   - ErrResyncRequired when the leader's buffer no longer covers fromRev.
 //   - ErrLeaderUnreachable after maxRetries consecutive connection failures.
 //   - ErrLeaderShutdown when the leader sent a graceful shutdown signal.
-func (c *Client) Follow(ctx context.Context, fromRev int64, applyFn func(wal.Entry) error) error {
+func (c *Client) Follow(ctx context.Context, fromRev int64, applyFn func([]wal.Entry) error) error {
 	consecutiveFailures := 0
 	for {
 		nextRev, err := c.followOnce(ctx, fromRev, applyFn)
@@ -130,13 +132,18 @@ func (c *Client) Follow(ctx context.Context, fromRev int64, applyFn func(wal.Ent
 
 // followOnce makes one streaming attempt using the shared connection.
 // Returns the next fromRev (last applied revision + 1) on any error.
-func (c *Client) followOnce(ctx context.Context, fromRev int64, applyFn func(wal.Entry) error) (int64, error) {
+func (c *Client) followOnce(ctx context.Context, fromRev int64, applyFn func([]wal.Entry) error) (int64, error) {
 	conn, err := c.getConn()
 	if err != nil {
 		return fromRev, err
 	}
 
-	stream, err := NewWalStreamClient(conn).Follow(ctx, &FollowRequest{
+	// Cancel the stream context on return so the receiver goroutine below
+	// exits cleanly when followOnce returns for any reason.
+	streamCtx, streamCancel := context.WithCancel(ctx)
+	defer streamCancel()
+
+	stream, err := NewWalStreamClient(conn).Follow(streamCtx, &FollowRequest{
 		FromRevision: fromRev,
 		NodeID:       c.nodeID,
 	})
@@ -146,22 +153,64 @@ func (c *Client) followOnce(ctx context.Context, fromRev int64, applyFn func(wal
 
 	logrus.Infof("peer: connected to leader %s (fromRev=%d)", c.leaderAddr, fromRev)
 
+	// entryC buffers entries received from the stream so the main loop can
+	// drain multiple entries per batch, amortising WAL fsyncs (AppendBatch
+	// does one fsync for the whole batch rather than one per entry).
+	entryC := make(chan wal.Entry, 512)
+	recvErrC := make(chan error, 1)
+
+	go func() {
+		for {
+			msg, err := stream.Recv()
+			if err != nil {
+				recvErrC <- err
+				return
+			}
+			if msg.Shutdown {
+				recvErrC <- ErrLeaderShutdown
+				return
+			}
+			select {
+			case entryC <- MsgToEntry(msg):
+			case <-streamCtx.Done():
+				recvErrC <- streamCtx.Err()
+				return
+			}
+		}
+	}()
+
 	for {
-		msg, err := stream.Recv()
-		if err != nil {
+		// Block until at least one entry or an error.
+		var batch []wal.Entry
+		select {
+		case e := <-entryC:
+			batch = append(batch, e)
+		case err := <-recvErrC:
 			return fromRev, err
 		}
-		if msg.Shutdown {
-			return fromRev, ErrLeaderShutdown
+
+		// Drain any additional entries that are already buffered so we can
+		// process them in a single AppendBatch (one fsync for the lot).
+	drain:
+		for {
+			select {
+			case e := <-entryC:
+				batch = append(batch, e)
+			default:
+				break drain
+			}
 		}
-		e := MsgToEntry(msg)
-		if err := applyFn(e); err != nil {
-			return fromRev, err
+
+		batchStartRev := fromRev
+		if err := applyFn(batch); err != nil {
+			return batchStartRev, err
 		}
-		fromRev = e.Revision + 1
-		// ACK after durable local WAL write (applyFn writes to WAL before Pebble).
-		// Best-effort: a send error just causes reconnect, which is safe.
-		if err := stream.SendAck(e.Revision); err != nil {
+		fromRev = batch[len(batch)-1].Revision + 1
+
+		// ACK the highest revision in the batch. The leader only needs the
+		// maximum ACK'd revision to advance its quorum counter, so one ACK
+		// per batch is enough regardless of how many entries it contained.
+		if err := stream.SendAck(batch[len(batch)-1].Revision); err != nil {
 			return fromRev, err
 		}
 	}

--- a/internal/peer/peer.go
+++ b/internal/peer/peer.go
@@ -9,7 +9,9 @@ package peer
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/json"
+	"fmt"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -50,14 +52,106 @@ func IsLeaderShutdown(err error) bool {
 	return ok && s.Code() == codes.Unavailable && s.Message() == "leader_shutdown"
 }
 
-// ── JSON codec ────────────────────────────────────────────────────────────────
+// ── Binary codec ─────────────────────────────────────────────────────────────
 
-// Codec is the JSON codec used for all peer gRPC messages.
+// Codec encodes peer gRPC messages. Hot-path messages (WalEntryMsg, AckMsg)
+// use a compact binary format; all other messages fall back to JSON.
+//
+// WalEntryMsg wire layout (little-endian, 50-byte fixed header):
+//
+//	[revision  : int64  ]  @0
+//	[term      : uint64 ]  @8
+//	[createRev : int64  ]  @16
+//	[prevRev   : int64  ]  @24
+//	[lease     : int64  ]  @32
+//	[op        : uint8  ]  @40
+//	[flags     : uint8  ]  @41  bit0 = shutdown
+//	[keyLen    : uint32 ]  @42
+//	[key bytes ]           @46
+//	[valueLen  : uint32 ]  @46+keyLen
+//	[value bytes]          @50+keyLen
+//
+// AckMsg wire layout:
+//
+//	[revision  : int64  ]  8 bytes
 type Codec struct{}
 
-func (Codec) Marshal(v interface{}) ([]byte, error)      { return json.Marshal(v) }
-func (Codec) Unmarshal(data []byte, v interface{}) error { return json.Unmarshal(data, v) }
-func (Codec) Name() string                               { return "strata-json" }
+func (Codec) Name() string { return "strata-bin" }
+
+func (Codec) Marshal(v interface{}) ([]byte, error) {
+	switch m := v.(type) {
+	case *WalEntryMsg:
+		return marshalWalEntryMsg(m)
+	case *AckMsg:
+		buf := make([]byte, 8)
+		binary.LittleEndian.PutUint64(buf, uint64(m.Revision))
+		return buf, nil
+	default:
+		return json.Marshal(v)
+	}
+}
+
+func (Codec) Unmarshal(data []byte, v interface{}) error {
+	switch m := v.(type) {
+	case *WalEntryMsg:
+		return unmarshalWalEntryMsg(data, m)
+	case *AckMsg:
+		if len(data) < 8 {
+			return fmt.Errorf("peer: AckMsg too short (%d bytes)", len(data))
+		}
+		m.Revision = int64(binary.LittleEndian.Uint64(data))
+		return nil
+	default:
+		return json.Unmarshal(data, v)
+	}
+}
+
+const walEntryMsgFixedSize = 50
+
+func marshalWalEntryMsg(m *WalEntryMsg) ([]byte, error) {
+	kl := len(m.Key)
+	vl := len(m.Value)
+	buf := make([]byte, walEntryMsgFixedSize+kl+vl)
+	binary.LittleEndian.PutUint64(buf[0:], uint64(m.Revision))
+	binary.LittleEndian.PutUint64(buf[8:], m.Term)
+	binary.LittleEndian.PutUint64(buf[16:], uint64(m.CreateRevision))
+	binary.LittleEndian.PutUint64(buf[24:], uint64(m.PrevRevision))
+	binary.LittleEndian.PutUint64(buf[32:], uint64(m.Lease))
+	buf[40] = m.Op
+	if m.Shutdown {
+		buf[41] = 1
+	}
+	binary.LittleEndian.PutUint32(buf[42:], uint32(kl))
+	copy(buf[46:], m.Key)
+	binary.LittleEndian.PutUint32(buf[46+kl:], uint32(vl))
+	copy(buf[50+kl:], m.Value)
+	return buf, nil
+}
+
+func unmarshalWalEntryMsg(data []byte, m *WalEntryMsg) error {
+	if len(data) < walEntryMsgFixedSize {
+		return fmt.Errorf("peer: WalEntryMsg too short (%d bytes)", len(data))
+	}
+	m.Revision = int64(binary.LittleEndian.Uint64(data[0:]))
+	m.Term = binary.LittleEndian.Uint64(data[8:])
+	m.CreateRevision = int64(binary.LittleEndian.Uint64(data[16:]))
+	m.PrevRevision = int64(binary.LittleEndian.Uint64(data[24:]))
+	m.Lease = int64(binary.LittleEndian.Uint64(data[32:]))
+	m.Op = data[40]
+	m.Shutdown = data[41] != 0
+	kl := int(binary.LittleEndian.Uint32(data[42:]))
+	if len(data) < walEntryMsgFixedSize+kl {
+		return fmt.Errorf("peer: WalEntryMsg truncated at key (need %d have %d)", walEntryMsgFixedSize+kl, len(data))
+	}
+	m.Key = string(data[46 : 46+kl])
+	vl := int(binary.LittleEndian.Uint32(data[46+kl:]))
+	if len(data) < walEntryMsgFixedSize+kl+vl {
+		return fmt.Errorf("peer: WalEntryMsg truncated at value (need %d have %d)", walEntryMsgFixedSize+kl+vl, len(data))
+	}
+	m.Value = make([]byte, vl)
+	copy(m.Value, data[50+kl:])
+	return nil
+}
 
 // ── WAL stream message types ──────────────────────────────────────────────────
 

--- a/internal/peer/peer_test.go
+++ b/internal/peer/peer_test.go
@@ -47,8 +47,10 @@ func TestStreamDelivery(t *testing.T) {
 
 	received := make(chan wal.Entry, 16)
 	go func() {
-		cli.Follow(ctx, 1, func(e wal.Entry) error {
-			received <- e
+		cli.Follow(ctx, 1, func(entries []wal.Entry) error {
+			for _, e := range entries {
+				received <- e
+			}
 			return nil
 		})
 	}()
@@ -90,8 +92,10 @@ func TestCatchUp(t *testing.T) {
 
 	received := make(chan wal.Entry, 16)
 	go func() {
-		cli.Follow(ctx, 1, func(e wal.Entry) error {
-			received <- e
+		cli.Follow(ctx, 1, func(entries []wal.Entry) error {
+			for _, e := range entries {
+				received <- e
+			}
 			return nil
 		})
 	}()
@@ -139,7 +143,7 @@ func TestResyncRequired(t *testing.T) {
 	errCh := make(chan error, 1)
 	go func() {
 		// Ask for revision 1, which has been evicted from the 3-entry buffer.
-		errCh <- cli.Follow(ctx, 1, func(e wal.Entry) error { return nil })
+		errCh <- cli.Follow(ctx, 1, func([]wal.Entry) error { return nil })
 	}()
 
 	select {
@@ -209,7 +213,7 @@ func TestLeaderUnreachable(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
-	err := cli.Follow(ctx, 1, func(e wal.Entry) error { return nil })
+	err := cli.Follow(ctx, 1, func([]wal.Entry) error { return nil })
 	if !peer.IsLeaderUnreachable(err) {
 		t.Errorf("expected IsLeaderUnreachable, got: %v", err)
 	}
@@ -229,8 +233,10 @@ func TestMultipleFollowers(t *testing.T) {
 		received[i] = make(chan wal.Entry, 16)
 		ch := received[i]
 		cli := peer.NewClient(addr, fmt.Sprintf("follower-%d", i), 3, nil)
-		go cli.Follow(ctx, 1, func(e wal.Entry) error {
-			ch <- e
+		go cli.Follow(ctx, 1, func(entries []wal.Entry) error {
+			for _, e := range entries {
+				ch <- e
+			}
 			return nil
 		})
 	}
@@ -274,10 +280,12 @@ func TestNoDuplicatesOnCatchUp(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		cli.Follow(ctx, 1, func(e wal.Entry) error {
-			revisions = append(revisions, e.Revision)
-			if e.Revision >= 6 {
-				cancel() // we have enough
+		cli.Follow(ctx, 1, func(entries []wal.Entry) error {
+			for _, e := range entries {
+				revisions = append(revisions, e.Revision)
+				if e.Revision >= 6 {
+					cancel() // we have enough
+				}
 			}
 			return nil
 		})

--- a/node.go
+++ b/node.go
@@ -786,33 +786,40 @@ func (n *Node) followLoop(bgCtx context.Context) {
 	fromRev := n.db.CurrentRevision() + 1
 
 	for {
-		err := cli.Follow(bgCtx, fromRev, func(e wal.Entry) error {
+		err := cli.Follow(bgCtx, fromRev, func(entries []wal.Entry) error {
 			// Followers must apply a contiguous revision stream. If the leader
 			// stream skips (or rewinds) a revision, force a full resync rather
 			// than silently advancing currentRev with holes.
-			if e.Revision != fromRev {
-				return peer.ErrResyncRequired
+			for i, e := range entries {
+				if e.Revision != fromRev+int64(i) {
+					return peer.ErrResyncRequired
+				}
 			}
-			if err := n.wal.Append(&e); err != nil {
+			ptrs := make([]*wal.Entry, len(entries))
+			for i := range entries {
+				ptrs[i] = &entries[i]
+			}
+			if err := n.wal.AppendBatch(bgCtx, ptrs); err != nil {
 				return err
 			}
-			if err := n.db.Apply([]wal.Entry{e}); err != nil {
+			if err := n.db.Apply(entries); err != nil {
 				return err
 			}
 			// Track the leader's term so attemptPromotion uses the correct
 			// floorTerm when calling TakeOver.  Without this, n.term stays at
 			// its Open() value and TakeOver backs off because it sees the
 			// current lock term as "already taken over at a higher term".
-			if e.Term > n.term {
+			// The last entry in the batch has the highest-or-equal term.
+			if last := entries[len(entries)-1]; last.Term > n.term {
 				n.mu.Lock()
-				if e.Term > n.term {
-					n.term = e.Term
+				if last.Term > n.term {
+					n.term = last.Term
 				}
 				n.mu.Unlock()
 			}
 			// Advance only after a successful apply so a reconnect retries
-			// the same revision rather than skipping it.
-			fromRev = e.Revision + 1
+			// from the start of the failed batch rather than skipping it.
+			fromRev = entries[len(entries)-1].Revision + 1
 			return nil
 		})
 
@@ -1632,36 +1639,46 @@ func (n *Node) commitLoop(ctx context.Context) {
 		for i, req := range batch {
 			entries[i] = &req.entry
 		}
-		err := n.wal.AppendBatch(batchCtx, entries)
-		batchCancel() // release watcher goroutines
 
-		// Broadcast to followers immediately after WAL append — before Pebble
-		// apply — so they can start processing (WAL write + ACK) in parallel.
-		// Ordering note: Broadcast must happen in revision order to avoid the
-		// peer server's maxSent dedup filter dropping entries.
-		if err == nil && n.peerSrv != nil {
+		var err error
+		if n.peerSrv != nil {
+			// Pipeline: run the leader WAL fsync concurrently with follower
+			// replication. Broadcast entries to followers immediately so their
+			// WAL writes overlap the leader's fsync. The leader fsync and the
+			// follower quorum ACKs are both required before signalling callers,
+			// preserving the same durability guarantee as the sequential path.
+			//
+			// Broadcasting before the leader fsync completes is safe: a client
+			// is only ACKed after both the leader fsync and the quorum ACK
+			// succeed. If the leader crashes before its fsync, the entry is
+			// not yet committed, matching standard Raft behaviour (etcd uses
+			// the same concurrent-write pattern).
+			//
+			// Ordering note: Broadcast must happen in revision order to avoid
+			// the peer server's maxSent dedup filter dropping entries.
+			walErrC := make(chan error, 1)
+			go func() { walErrC <- n.wal.AppendBatch(batchCtx, entries) }()
+
 			for _, req := range batch {
 				n.peerSrv.Broadcast(&req.entry)
 			}
-		}
 
-		// Wait for follower ACKs according to the configured policy before
-		// committing to Pebble. In the default quorum mode this guarantees
-		// the entry exists on a majority of nodes' WALs before the caller sees
-		// success.
-		//
-		// Use the commit loop's own context (node lifetime), NOT batchCtx.
-		// batchCtx is cancelled immediately after AppendBatch to release the
-		// per-caller watcher goroutines; passing it here would cause
-		// WaitForFollowers to return instantly, defeating quorum commit.
-		//
-		// Availability policy: if all followers disconnect mid-wait, we
-		// proceed anyway — the entry is already durable in the leader's WAL
-		// and will be replayed by followers when they reconnect.
-		if err == nil && n.peerSrv != nil {
+			// Wait for follower ACKs according to the configured policy.
+			// Use the commit loop's own context (node lifetime), NOT batchCtx:
+			// batchCtx is cancelled after AppendBatch returns and passing it
+			// here would cause WaitForFollowers to return instantly.
+			//
+			// Availability policy: if all followers disconnect mid-wait, we
+			// proceed anyway — the entry is already durable in the leader's
+			// WAL and will be replayed by followers when they reconnect.
 			maxRev := batch[len(batch)-1].entry.Revision
 			_ = n.peerSrv.WaitForFollowers(ctx, maxRev, peer.WaitMode(n.cfg.FollowerWaitMode))
+
+			err = <-walErrC
+		} else {
+			err = n.wal.AppendBatch(batchCtx, entries)
 		}
+		batchCancel() // release watcher goroutines
 
 		// Apply all entries to Pebble as one batch (in order).
 		if err == nil {


### PR DESCRIPTION
Strata now beats etcd on par-put (+11%), seq-get (+33%), and mixed (+20%) in a 3-node cluster after three optimisations:                                                                                  
 - Leader fsync pipelined with follower broadcast                                             
 - Follower AppendBatch (one fsync per batch, was one per entry)                 
 - Binary wire codec for WalEntryMsg/AckMsg (6× faster marshal, 32× faster unmarshal vs stdlib JSON)  