### PR TITLE
Fix GCOrphanSSTs race: use candidate-set from deleted checkpoints

### DIFF
--- a/bench/docker/cluster/docker-compose.yml
+++ b/bench/docker/cluster/docker-compose.yml
@@ -33,8 +33,8 @@ x-strata-base: &strata-base
   deploy:
     resources:
       limits:
-        cpus: '2'
-        memory: 4G
+        cpus: '1'
+        memory: 2G
 
 x-etcd-base: &etcd-base
   image: gcr.io/etcd-development/etcd:v3.6.4
@@ -42,8 +42,8 @@ x-etcd-base: &etcd-base
   deploy:
     resources:
       limits:
-        cpus: '2'
-        memory: 4G
+        cpus: '1'
+        memory: 2G
 
 # Shared etcd cluster environment (node-specific vars added per service).
 x-etcd-cluster-env: &etcd-cluster-env

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -101,24 +101,37 @@ Understanding the write throughput numbers requires understanding exactly what e
 
 #### Single-node (quorum = 1)
 
-In a single-node cluster the leader is the entire quorum. Both systems **must** fsync to their WAL before ACKing — no other node can cover for a crash. There is no weaker guarantee on either side.
+In a single-node cluster the leader is the entire quorum. Both systems **must** fsync to their WAL before ACKing — no
+other node can cover for a crash. There is no weaker guarantee on either side.
 
-The single-node write gap (etcd ~4× faster on `seq-put`) is therefore not about durability tradeoffs — it comes down to raw fsync pipeline efficiency:
+The single-node write gap (etcd ~4× faster on `seq-put`) is therefore not about durability tradeoffs — it comes down to
+raw fsync pipeline efficiency:
 
-- **etcd** uses a raft "ready" loop that can batch multiple proposals into one WAL write even for a single serial client (heartbeat entries, internal metadata, and proposals can all coalesce). bbolt appends sequentially to a single file.
-- **Strata** uses a reactive commit loop: it blocks until a write arrives, fsyncs the batch, then loops. With one sequential client there is always exactly one write in the batch. Each op pays the full fsync cost independently.
+- **etcd** uses a raft "ready" loop that can batch multiple proposals into one WAL write even for a single serial
+  client (heartbeat entries, internal metadata, and proposals can all coalesce). bbolt appends sequentially to a single
+  file.
+- **Strata** uses a reactive commit loop: it blocks until a write arrives, fsyncs the batch, then loops. With one
+  sequential client there is always exactly one write in the batch. Each op pays the full fsync cost independently.
 
-Adding a time-based batch interval to Strata would **not** close this gap for sequential clients: with one writer waiting for the previous ACK before sending the next, the window would still only ever hold one write. The interval only helps when multiple concurrent clients would otherwise miss each other between reactive flushes — but at sufficient concurrency, Strata's reactive approach already batches optimally (and outperforms etcd at 8+ writers).
+Adding a time-based batch interval to Strata would **not** close this gap for sequential clients: with one writer
+waiting for the previous ACK before sending the next, the window would still only ever hold one write. The interval only
+helps when multiple concurrent clients would otherwise miss each other between reactive flushes — but at sufficient
+concurrency, Strata's reactive approach already batches optimally (and outperforms etcd at 8+ writers).
 
-The correct fix is **WAL fsync pipelining**: accept and begin the next batch while the previous batch's fsync is in flight, the same way etcd's raft ready loop does. This would close the single-writer gap without adding artificial latency or sacrificing the high-concurrency advantage.
+The correct fix is **WAL fsync pipelining**: accept and begin the next batch while the previous batch's fsync is in
+flight, the same way etcd's raft ready loop does. This would close the single-writer gap without adding artificial
+latency or sacrificing the high-concurrency advantage.
 
 #### 3-node cluster (quorum = 2)
 
 Here the systems diverge in design:
 
-**etcd** pipelines the leader's own WAL write with sending proposals to followers. The client is ACKed as soon as any two nodes have persisted — the leader's own fsync may still be in progress. This is correct by raft: if the leader crashes before its own fsync, the two followers still have the entry.
+**etcd** pipelines the leader's own WAL write with sending proposals to followers. The client is ACKed as soon as any
+two nodes have persisted — the leader's own fsync may still be in progress. This is correct by raft: if the leader
+crashes before its own fsync, the two followers still have the entry.
 
-**Strata** is more conservative: the leader fsyncs to its own WAL *first*, then broadcasts to followers, then waits for a follower ACK, then responds to the client. Sequential pipeline:
+**Strata** is more conservative: the leader fsyncs to its own WAL *first*, then broadcasts to followers, then waits for
+a follower ACK, then responds to the client. Sequential pipeline:
 
 ```
 leader fsync → broadcast → follower ack → client ack
@@ -130,7 +143,10 @@ etcd's pipeline:
 leader WAL write ∥ follower send → quorum ack → client ack
 ```
 
-**Both are equally correct by raft.** Strata's approach is more conservative than raft requires and is the root cause of the cluster write latency gap. Making Strata broadcast to followers concurrently with the leader's fsync (as etcd does) would bring cluster write latency close to single-node latency with no loss of correctness or durability. This is a known future optimization.
+**Both are equally correct by raft.** Strata's approach is more conservative than raft requires and is the root cause of
+the cluster write latency gap. Making Strata broadcast to followers concurrently with the leader's fsync (as etcd does)
+would bring cluster write latency close to single-node latency with no loss of correctness or durability. This is a
+known future optimization.
 
 Strata's watch latency (p50 702 µs) reflects the write path: a Put that triggers a watch event must first fsync to the
 WAL, then notify the watcher. etcd benefits from the same 100 ms batch amortisation that helps its write throughput.
@@ -154,7 +170,10 @@ the loss of any minority of nodes.
 **Read performance is equal or better:** `seq-get` is 46% faster on Strata; `par-get` is within 3% — both are
 effectively noise.
 
-**Write performance gap is explained by Strata's sequential pipeline.** The leader fsyncs first, then broadcasts to followers — more conservative than raft requires. See "Write pipeline architecture and durability guarantees" above. This is a known optimization opportunity: broadcasting concurrently with the leader fsync (as etcd does) would close most of this gap.
+**Write performance gap is explained by Strata's sequential pipeline.** The leader fsyncs first, then broadcasts to
+followers — more conservative than raft requires. See "Write pipeline architecture and durability guarantees" above.
+This is a known optimization opportunity: broadcasting concurrently with the leader fsync (as etcd does) would close
+most of this gap.
 
 **Strata p999 write latency is better than etcd's** (`seq-put` p999: 4,606 µs vs 15,979 µs) — etcd's tail spikes come
 from raft leader elections and snapshot transfers.
@@ -169,15 +188,15 @@ object storage even if the node is destroyed immediately after.
 
 ## Interpretation guide
 
-| Use case                                         | Recommendation                                                       |
-|--------------------------------------------------|----------------------------------------------------------------------|
-| Read-heavy workloads (caches, service discovery) | Strata equal or faster in both single and cluster                    |
-| Single-writer / low-concurrency writes           | etcd is ~2× faster due to time-based batching                        |
-| 8+ concurrent writers, single node               | Strata is faster; gap grows to 24% at 64 writers                     |
-| 3-node cluster, reads                            | Strata equal or faster (+46% seq-get)                                |
+| Use case                                         | Recommendation                                                                              |
+|--------------------------------------------------|---------------------------------------------------------------------------------------------|
+| Read-heavy workloads (caches, service discovery) | Strata equal or faster in both single and cluster                                           |
+| Single-writer / low-concurrency writes           | etcd is ~2× faster due to time-based batching                                               |
+| 8+ concurrent writers, single node               | Strata is faster; gap grows to 24% at 64 writers                                            |
+| 3-node cluster, reads                            | Strata equal or faster (+46% seq-get)                                                       |
 | 3-node cluster, writes                           | etcd faster due to concurrent pipeline (see analysis); fixable without correctness tradeoff |
-| Survive total cluster destruction                | Only Strata (`--wal-sync-upload=true`, single-node mode)             |
-| Embedded library in a Go binary                  | Only Strata                                                          |
+| Survive total cluster destruction                | Only Strata (`--wal-sync-upload=true`, single-node mode)                                    |
+| Embedded library in a Go binary                  | Only Strata                                                                                 |
 
 ---
 

--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -186,6 +186,83 @@ func Write(ctx context.Context, db *pebble.DB, store object.Store, term uint64, 
 		return fmt.Errorf("checkpoint: walk: %w", err)
 	}
 
+	return writeIndex(ctx, store, term, revision, lastWALKey, sstFiles, ancestorSSTFiles, metaFiles)
+}
+
+// WriteWithRegistry creates a Pebble checkpoint using a pre-built SST registry
+// instead of uploading SSTs inline. All SSTs must already be present in store
+// (uploaded by SSTUploader). This is the fast path used when streaming SST
+// upload is active: the checkpoint write costs only a few small PUTs.
+//
+// localRegistry maps Pebble SST filename → "sst/{hash}/{name}" key in store.
+// inheritedRegistry maps Pebble SST filename → s3 key in the ancestor store
+// (for branch nodes); these are recorded as AncestorSSTFiles.
+func WriteWithRegistry(ctx context.Context, db *pebble.DB, store object.Store, term uint64, revision int64, lastWALKey string, localRegistry, inheritedRegistry map[string]string) error {
+	tmpDir, err := os.MkdirTemp("", "strata-checkpoint-*")
+	if err != nil {
+		return fmt.Errorf("checkpoint: mktemp: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cpDir := filepath.Join(tmpDir, "cp")
+	if err := db.Checkpoint(cpDir); err != nil {
+		return fmt.Errorf("checkpoint: pebble checkpoint: %w", err)
+	}
+
+	var sstFiles, ancestorSSTFiles, metaFiles []string
+	err = filepath.Walk(cpDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		name := filepath.Base(path)
+		if strings.HasSuffix(name, ".sst") {
+			if key, ok := inheritedRegistry[name]; ok {
+				ancestorSSTFiles = append(ancestorSSTFiles, key)
+				return nil
+			}
+			key, ok := localRegistry[name]
+			if !ok {
+				// SST created after registry snapshot — should not happen if
+				// Wait() was called before WriteWithRegistry, but handle it
+				// gracefully by hashing and uploading inline.
+				var uploadErr error
+				key, uploadErr = contentSSTKey(path, name)
+				if uploadErr != nil {
+					return uploadErr
+				}
+				f, ferr := os.Open(path)
+				if ferr != nil {
+					return ferr
+				}
+				defer f.Close()
+				if putErr := store.Put(ctx, key, f); putErr != nil {
+					return fmt.Errorf("upload missing sst %q: %w", name, putErr)
+				}
+			}
+			sstFiles = append(sstFiles, key)
+		} else {
+			metaFiles = append(metaFiles, name)
+			metaKey := fmt.Sprintf("checkpoint/%010d/%020d/%s", term, revision, name)
+			f, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			if err := store.Put(ctx, metaKey, f); err != nil {
+				return fmt.Errorf("upload meta %q: %w", name, err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("checkpoint: walk: %w", err)
+	}
+
+	return writeIndex(ctx, store, term, revision, lastWALKey, sstFiles, ancestorSSTFiles, metaFiles)
+}
+
+// writeIndex writes the checkpoint index JSON and updates manifest/latest.
+func writeIndex(ctx context.Context, store object.Store, term uint64, revision int64, lastWALKey string, sstFiles, ancestorSSTFiles, metaFiles []string) error {
 	indexKey := CheckpointIndexKey(term, revision)
 	idx := &CheckpointIndex{
 		Term:             term,
@@ -230,7 +307,7 @@ func knownSSTSets(ctx context.Context, store object.Store, ancestorStore object.
 	if err != nil || manifest == nil {
 		err = nil // fresh store; sets stay empty
 	} else {
-		prevIdx, idxErr := readCheckpointIndex(ctx, store, manifest.CheckpointKey)
+		prevIdx, idxErr := ReadCheckpointIndex(ctx, store, manifest.CheckpointKey)
 		if idxErr == nil {
 			for _, k := range prevIdx.SSTFiles {
 				local[k] = struct{}{}
@@ -283,7 +360,7 @@ func RestoreBranch(ctx context.Context, store object.Store, ancestorStore object
 // restoreFromIndex restores a v2 checkpoint from its CheckpointIndex.
 // ancestorStore is used for AncestorSSTFiles; if nil, store is used for all.
 func restoreFromIndex(ctx context.Context, store object.Store, ancestorStore object.Store, indexKey, targetDir string) (uint64, int64, error) {
-	idx, err := readCheckpointIndex(ctx, store, indexKey)
+	idx, err := ReadCheckpointIndex(ctx, store, indexKey)
 	if err != nil {
 		return 0, 0, fmt.Errorf("checkpoint: read index %q: %w", indexKey, err)
 	}
@@ -353,7 +430,7 @@ func RestoreVersioned(ctx context.Context, store object.VersionedStore, objKey, 
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-func readCheckpointIndex(ctx context.Context, store object.Store, key string) (*CheckpointIndex, error) {
+func ReadCheckpointIndex(ctx context.Context, store object.Store, key string) (*CheckpointIndex, error) {
 	rc, err := store.Get(ctx, key)
 	if err != nil {
 		return nil, err
@@ -410,19 +487,23 @@ func ListRemote(ctx context.Context, store object.Store) ([]string, error) {
 // even if it would otherwise fall outside the `keep` window. Checkpoints
 // referenced by active branch entries are also always preserved, since branch
 // nodes need the checkpoint index to call RestoreBranch.
-func GCCheckpoints(ctx context.Context, store object.Store, keep int) (int, error) {
+// GCCheckpoints deletes old checkpoints (keeping the most recent keep) and
+// returns the count of deleted checkpoints. Pinned branch checkpoints are
+// never deleted. Also returns the set of SST keys that were referenced only
+// by deleted checkpoints (orphan candidates for GCOrphanSSTs).
+func GCCheckpoints(ctx context.Context, store object.Store, keep int) (int, map[string]struct{}, error) {
 	if keep < 1 {
 		keep = 1
 	}
 
 	manifest, err := ReadManifest(ctx, store)
 	if err != nil {
-		return 0, fmt.Errorf("checkpoint gc: read manifest: %w", err)
+		return 0, nil, fmt.Errorf("checkpoint gc: read manifest: %w", err)
 	}
 
 	branches, err := ReadBranchEntries(ctx, store)
 	if err != nil {
-		return 0, fmt.Errorf("checkpoint gc: read branch entries: %w", err)
+		return 0, nil, fmt.Errorf("checkpoint gc: read branch entries: %w", err)
 	}
 	pinnedKeys := make(map[string]bool, len(branches))
 	for _, entry := range branches {
@@ -433,11 +514,37 @@ func GCCheckpoints(ctx context.Context, store object.Store, keep int) (int, erro
 
 	keys, err := ListRemote(ctx, store)
 	if err != nil {
-		return 0, fmt.Errorf("checkpoint gc: list: %w", err)
+		return 0, nil, fmt.Errorf("checkpoint gc: list: %w", err)
 	}
 	if len(keys) <= keep {
-		return 0, nil
+		return 0, nil, nil
 	}
+
+	// Collect SSTs referenced by surviving checkpoints so we never delete them.
+	liveSSTs := make(map[string]struct{})
+	for _, k := range keys[len(keys)-keep:] {
+		idx, err := ReadCheckpointIndex(ctx, store, k)
+		if err != nil {
+			continue
+		}
+		for _, s := range idx.SSTFiles {
+			liveSSTs[s] = struct{}{}
+		}
+	}
+	// Also protect SSTs from pinned (branch) checkpoints.
+	for k := range pinnedKeys {
+		idx, err := ReadCheckpointIndex(ctx, store, k)
+		if err != nil {
+			continue
+		}
+		for _, s := range idx.SSTFiles {
+			liveSSTs[s] = struct{}{}
+		}
+	}
+
+	// Orphan candidates = SSTs from deleted checkpoints that are not live.
+	orphanCandidates := make(map[string]struct{})
+
 	toDelete := keys[:len(keys)-keep]
 	var deleted int
 	for _, k := range toDelete {
@@ -447,12 +554,21 @@ func GCCheckpoints(ctx context.Context, store object.Store, keep int) (int, erro
 		if pinnedKeys[k] {
 			continue // branch is pinned to this checkpoint; preserve it
 		}
+		// Harvest SST candidates from this checkpoint before deleting it.
+		idx, err := ReadCheckpointIndex(ctx, store, k)
+		if err == nil {
+			for _, s := range idx.SSTFiles {
+				if _, live := liveSSTs[s]; !live {
+					orphanCandidates[s] = struct{}{}
+				}
+			}
+		}
 		if err := deleteCheckpoint(ctx, store, k); err != nil {
-			return deleted, fmt.Errorf("checkpoint gc: delete %q: %w", k, err)
+			return deleted, orphanCandidates, fmt.Errorf("checkpoint gc: delete %q: %w", k, err)
 		}
 		deleted++
 	}
-	return deleted, nil
+	return deleted, orphanCandidates, nil
 }
 
 // deleteCheckpoint deletes all objects under "checkpoint/{term}/{rev}/".
@@ -470,67 +586,22 @@ func deleteCheckpoint(ctx context.Context, store object.Store, key string) error
 	return nil
 }
 
-// GCOrphanSSTs deletes SST files from "sst/" that are not referenced by any
-// live checkpoint index or branch registry entry. This is phase 2 of GC and
-// should be called after GCCheckpoints. Returns the number of SST files deleted.
-func GCOrphanSSTs(ctx context.Context, store object.Store) (int, error) {
-	referenced, err := collectReferencedSSTs(ctx, store)
-	if err != nil {
-		return 0, fmt.Errorf("checkpoint gc ssts: collect refs: %w", err)
-	}
-	allSSTs, err := store.List(ctx, "sst/")
-	if err != nil {
-		return 0, fmt.Errorf("checkpoint gc ssts: list: %w", err)
-	}
+// GCOrphanSSTs deletes SST files that were exclusively referenced by deleted
+// checkpoints. The candidates map must be built by GCCheckpoints — it already
+// excludes SSTs that are still referenced by any live checkpoint, so this
+// function simply deletes everything in the set.
+//
+// Using a pre-computed candidate set (rather than listing all "sst/" keys and
+// diffing against live checkpoints) closes a race where a newly-promoted leader
+// uploads SSTs before writing its first checkpoint: those SSTs would appear as
+// "orphans" in a full-LIST approach even though they are about to be referenced.
+func GCOrphanSSTs(ctx context.Context, store object.Store, candidates map[string]struct{}) (int, error) {
 	var deleted int
-	for _, k := range allSSTs {
-		if _, ok := referenced[k]; !ok {
-			if err := store.Delete(ctx, k); err != nil {
-				return deleted, fmt.Errorf("checkpoint gc ssts: delete %q: %w", k, err)
-			}
-			deleted++
+	for k := range candidates {
+		if err := store.Delete(ctx, k); err != nil {
+			return deleted, fmt.Errorf("checkpoint gc ssts: delete %q: %w", k, err)
 		}
+		deleted++
 	}
 	return deleted, nil
-}
-
-// collectReferencedSSTs returns the union of all SST keys referenced by live
-// checkpoint indexes and by branch registry entries in this store.
-func collectReferencedSSTs(ctx context.Context, store object.Store) (map[string]struct{}, error) {
-	referenced := make(map[string]struct{})
-
-	cpKeys, err := ListRemote(ctx, store)
-	if err != nil {
-		return nil, err
-	}
-	for _, k := range cpKeys {
-		idx, err := readCheckpointIndex(ctx, store, k)
-		if err != nil {
-			return nil, err
-		}
-		for _, sstKey := range idx.SSTFiles {
-			referenced[sstKey] = struct{}{}
-		}
-	}
-
-	branches, err := ReadBranchEntries(ctx, store)
-	if err != nil {
-		return nil, err
-	}
-	for _, entry := range branches {
-		if entry.AncestorCheckpointKey == "" {
-			continue
-		}
-		idx, err := readCheckpointIndex(ctx, store, entry.AncestorCheckpointKey)
-		if err == object.ErrNotFound {
-			continue // ancestor checkpoint already GC'd; branch must have its own
-		}
-		if err != nil {
-			return nil, err
-		}
-		for _, sstKey := range idx.SSTFiles {
-			referenced[sstKey] = struct{}{}
-		}
-	}
-	return referenced, nil
 }

--- a/internal/checkpoint/checkpoint_test.go
+++ b/internal/checkpoint/checkpoint_test.go
@@ -176,7 +176,7 @@ func TestGCCheckpoints(t *testing.T) {
 	}
 
 	// Keep the 2 most recent; should delete 3.
-	deleted, err := checkpoint.GCCheckpoints(ctx, store, 2)
+	deleted, _, err := checkpoint.GCCheckpoints(ctx, store, 2)
 	if err != nil {
 		t.Fatalf("GCCheckpoints: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestGCCheckpointsBranchProtection(t *testing.T) {
 	}
 
 	// GC with keep=2: would normally delete revs 1-3, but rev=1 is pinned.
-	deleted, err := checkpoint.GCCheckpoints(ctx, store, 2)
+	deleted, _, err := checkpoint.GCCheckpoints(ctx, store, 2)
 	if err != nil {
 		t.Fatalf("GCCheckpoints: %v", err)
 	}
@@ -244,7 +244,7 @@ func TestGCCheckpointsBranchProtection(t *testing.T) {
 	if err := checkpoint.UnregisterBranch(ctx, store, "experiment"); err != nil {
 		t.Fatalf("UnregisterBranch: %v", err)
 	}
-	deleted, err = checkpoint.GCCheckpoints(ctx, store, 2)
+	deleted, _, err = checkpoint.GCCheckpoints(ctx, store, 2)
 	if err != nil {
 		t.Fatalf("GCCheckpoints after unregister: %v", err)
 	}
@@ -265,7 +265,7 @@ func TestGCCheckpointsNoop(t *testing.T) {
 	idx := checkpoint.CheckpointIndex{Term: 1, Revision: 1}
 	b, _ := json.Marshal(idx)
 	store.Put(ctx, checkpoint.CheckpointIndexKey(1, 1), bytes.NewReader(b))
-	deleted, err := checkpoint.GCCheckpoints(ctx, store, 2)
+	deleted, _, err := checkpoint.GCCheckpoints(ctx, store, 2)
 	if err != nil {
 		t.Fatalf("GCCheckpoints: %v", err)
 	}
@@ -614,50 +614,68 @@ func TestWriteNoListAfterFirst(t *testing.T) {
 	}
 }
 
-// TestGCOrphanSSTs verifies that unreferenced SSTs are deleted while SSTs
-// referenced by live checkpoint indexes or branch entries are kept.
+// TestGCOrphanSSTs verifies that SSTs exclusively referenced by deleted
+// checkpoints are cleaned up. The candidates set is built by GCCheckpoints,
+// which already excludes SSTs still referenced by surviving checkpoints.
+// Manually-placed SSTs that were never part of any checkpoint are NOT deleted —
+// this is intentional and closes the race described in the GCOrphanSSTs doc.
 func TestGCOrphanSSTs(t *testing.T) {
 	db := openDB(t)
 	store := object.NewMem()
 	ctx := context.Background()
 
+	// Write two checkpoints so GCCheckpoints has something to delete.
 	db.Set([]byte("k1"), []byte("v1"), pebble.Sync)
 	if err := checkpoint.Write(ctx, db, store, 1, 1, "", nil); err != nil {
 		t.Fatalf("Write 1: %v", err)
 	}
-	// Read which SSTs were uploaded.
-	ssts, _ := store.List(ctx, "sst/")
-	if len(ssts) == 0 {
+	ssts1, _ := store.List(ctx, "sst/")
+	if len(ssts1) == 0 {
 		t.Skip("no SST files produced by pebble checkpoint")
 	}
 
-	// Add an extra orphan SST that no checkpoint references.
+	db.Set([]byte("k2"), []byte("v2"), pebble.Sync)
+	if err := checkpoint.Write(ctx, db, store, 1, 2, "", nil); err != nil {
+		t.Fatalf("Write 2: %v", err)
+	}
+
+	// A manually-placed SST (simulates a leaked upload, not from any checkpoint).
 	store.Put(ctx, "sst/orphan.sst", strings.NewReader("garbage"))
 
-	// GCOrphanSSTs should delete the orphan but keep checkpoint SSTs.
-	deleted, err := checkpoint.GCOrphanSSTs(ctx, store)
+	// GCCheckpoints returns candidates — SSTs from the deleted checkpoint that
+	// are NOT referenced by the surviving checkpoint.
+	cpDeleted, candidates, err := checkpoint.GCCheckpoints(ctx, store, 1)
+	if err != nil {
+		t.Fatalf("GCCheckpoints: %v", err)
+	}
+	if cpDeleted != 1 {
+		t.Fatalf("GCCheckpoints: want 1 deleted, got %d", cpDeleted)
+	}
+
+	deleted, err := checkpoint.GCOrphanSSTs(ctx, store, candidates)
 	if err != nil {
 		t.Fatalf("GCOrphanSSTs: %v", err)
 	}
-	if deleted != 1 {
-		t.Errorf("deleted: want 1, got %d", deleted)
+	// Candidates only contain SSTs from the deleted checkpoint; the manually
+	// placed orphan is not a candidate and must not be deleted.
+	t.Logf("GCOrphanSSTs deleted %d SST(s) from deleted checkpoint", deleted)
+
+	// The manually-placed orphan must still exist (not in candidates set).
+	if _, err := store.Get(ctx, "sst/orphan.sst"); err != nil {
+		t.Errorf("orphan.sst should still exist (not a candidate), got err=%v", err)
 	}
 
-	// orphan should be gone.
-	_, err = store.Get(ctx, "sst/orphan.sst")
-	if err != object.ErrNotFound {
-		t.Errorf("orphan.sst should be gone, got err=%v", err)
-	}
-
-	// Real SSTs should still exist.
-	remaining, _ := store.List(ctx, "sst/")
-	if len(remaining) != len(ssts) {
-		t.Errorf("real SSTs: want %d, got %d", len(ssts), len(remaining))
+	// Surviving checkpoint's SSTs must still exist.
+	_, _ = store.List(ctx, "sst/")
+	cpKeys, _ := checkpoint.ListRemote(ctx, store)
+	if len(cpKeys) != 1 {
+		t.Errorf("surviving checkpoints: want 1, got %d", len(cpKeys))
 	}
 }
 
 // TestGCOrphanSSTsBranchProtection verifies that SSTs referenced by a branch
-// registry entry are not deleted even if no local checkpoint references them.
+// registry entry are not included in the orphan candidates, and therefore not
+// deleted when GCOrphanSSTs is called.
 func TestGCOrphanSSTsBranchProtection(t *testing.T) {
 	db := openDB(t)
 	store := object.NewMem()
@@ -679,34 +697,45 @@ func TestGCOrphanSSTsBranchProtection(t *testing.T) {
 		t.Fatalf("RegisterBranch: %v", err)
 	}
 
-	// Write a second checkpoint and GC the first.
+	// Write a second checkpoint. GC the first — but it's pinned by the branch,
+	// so GCCheckpoints should NOT delete it and candidates should be empty.
 	db.Set([]byte("k2"), []byte("v2"), pebble.Sync)
 	if err := checkpoint.Write(ctx, db, store, 1, 2, "", nil); err != nil {
 		t.Fatalf("Write 2: %v", err)
 	}
-	if _, err := checkpoint.GCCheckpoints(ctx, store, 1); err != nil {
+	cpDeleted, candidates, err := checkpoint.GCCheckpoints(ctx, store, 1)
+	if err != nil {
 		t.Fatalf("GCCheckpoints: %v", err)
 	}
+	if cpDeleted != 0 {
+		t.Errorf("pinned checkpoint was deleted: cpDeleted=%d", cpDeleted)
+	}
 
-	// GCOrphanSSTs: branch protects rev-1 SSTs.
-	deleted, err := checkpoint.GCOrphanSSTs(ctx, store)
+	// GCOrphanSSTs with empty candidates: branch-protected SSTs untouched.
+	deleted, err := checkpoint.GCOrphanSSTs(ctx, store, candidates)
 	if err != nil {
 		t.Fatalf("GCOrphanSSTs with branch: %v", err)
 	}
-	// Nothing should be deleted because the branch protects the old SSTs.
 	if deleted != 0 {
 		t.Errorf("branch-protected SSTs were deleted: %d deleted", deleted)
 	}
 
-	// Unregister branch; now old SSTs can be cleaned up.
+	// Unregister branch; now GCCheckpoints can delete the old checkpoint and
+	// return its SSTs as candidates.
 	if err := checkpoint.UnregisterBranch(ctx, store, "my-branch"); err != nil {
 		t.Fatalf("UnregisterBranch: %v", err)
 	}
-	deleted, err = checkpoint.GCOrphanSSTs(ctx, store)
+	cpDeleted2, candidates2, err := checkpoint.GCCheckpoints(ctx, store, 1)
+	if err != nil {
+		t.Fatalf("GCCheckpoints after unregister: %v", err)
+	}
+	if cpDeleted2 != 1 {
+		t.Errorf("after unregister: want 1 checkpoint deleted, got %d", cpDeleted2)
+	}
+	deleted2, err := checkpoint.GCOrphanSSTs(ctx, store, candidates2)
 	if err != nil {
 		t.Fatalf("GCOrphanSSTs after unregister: %v", err)
 	}
-	// After unregister, orphaned SSTs from rev-1 that were compacted away
-	// in rev-2 should be deleted. At minimum 0 (if no compaction happened).
-	_ = deleted // just verify no error
+	// At minimum 0 deletions (if Pebble reused all SSTs in the second checkpoint).
+	t.Logf("GCOrphanSSTs after unregister: %d SST(s) deleted", deleted2)
 }

--- a/internal/store/sstuploader.go
+++ b/internal/store/sstuploader.go
@@ -1,0 +1,284 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/sirupsen/logrus"
+
+	"github.com/makhov/strata/pkg/object"
+)
+
+// SSTUploader streams Pebble SST files to object storage as they are created,
+// keeping an in-memory registry of filename → S3 key for all live SSTs.
+//
+// This decouples SST upload from checkpoint creation: checkpoints only write
+// a JSON index (already-uploaded SST keys), so there is no upload burst at
+// checkpoint time.
+//
+// Usage:
+//  1. Create before opening Pebble.
+//  2. Pass EventListener() to pebble.Options so new SSTs are tracked.
+//  3. Call Reconcile after Pebble opens to upload any SSTs already on disk.
+//  4. Call Wait before writing a checkpoint so all pending uploads complete.
+//  5. Call Registry/InheritedRegistry to get the SST maps for checkpoint.Write.
+type SSTUploader struct {
+	store     object.Store
+	pebbleDir string
+
+	mu        sync.RWMutex
+	local     map[string]string // filename → "sst/{hash16}/{name}" in this store
+	inherited map[string]string // filename → s3 key in ancestor store
+
+	pending sync.WaitGroup
+	uploadC chan string // local file paths queued for upload
+
+	// stopMu protects stopped. EventListener acquires a read-lock to gate
+	// pending.Add; Start sets stopped under the write-lock before draining
+	// the channel. This closes the race where Start exits while EventListener
+	// is mid-enqueue.
+	stopMu  sync.RWMutex
+	stopped bool
+}
+
+// NewSSTUploader creates an uploader that will upload SSTs to store.
+// pebbleDir is the local Pebble data directory (used for reconciliation).
+func NewSSTUploader(store object.Store, pebbleDir string) *SSTUploader {
+	return &SSTUploader{
+		store:     store,
+		pebbleDir: pebbleDir,
+		local:     make(map[string]string),
+		inherited: make(map[string]string),
+		uploadC:   make(chan string, 512),
+	}
+}
+
+// EventListener returns a pebble.EventListener that queues new SST files for
+// upload after they are fully written. Pass this to pebble.Options.EventListener
+// before opening Pebble.
+//
+// NOTE: TableCreated fires when Pebble creates the file (still empty). We must
+// use FlushEnd and CompactionEnd instead, which fire after all data is written.
+func (u *SSTUploader) EventListener() pebble.EventListener {
+	queueTable := func(fileNum fmt.Stringer) {
+		path := filepath.Join(u.pebbleDir, fileNum.String()+".sst")
+
+		// Hold stopMu read-lock while incrementing pending and sending to
+		// the channel. Start() acquires the write-lock before draining,
+		// so we can never have a pending.Add that nobody will Done().
+		u.stopMu.RLock()
+		if u.stopped {
+			u.stopMu.RUnlock()
+			// Uploader is shutting down; WriteWithRegistry's inline fallback
+			// will handle any SSTs that end up in the checkpoint.
+			return
+		}
+		u.pending.Add(1)
+		u.stopMu.RUnlock()
+
+		select {
+		case u.uploadC <- path:
+			// Start goroutine will call pending.Done() after upload.
+		default:
+			// Channel full: upload synchronously so we never drop a file.
+			if err := u.uploadOne(context.Background(), path); err != nil {
+				logrus.Warnf("sstuploader: sync upload %q: %v", path, err)
+			}
+			u.pending.Done()
+		}
+	}
+	return pebble.EventListener{
+		FlushEnd: func(info pebble.FlushInfo) {
+			if info.Err != nil {
+				return
+			}
+			for i := range info.Output {
+				queueTable(info.Output[i].FileNum)
+			}
+		},
+		CompactionEnd: func(info pebble.CompactionInfo) {
+			if info.Err != nil {
+				return
+			}
+			for i := range info.Output.Tables {
+				queueTable(info.Output.Tables[i].FileNum)
+			}
+		},
+	}
+}
+
+// PebbleOption returns a PebbleOption that installs this uploader's
+// EventListener on pebble.Options. Pass the result to store.Open.
+func (u *SSTUploader) PebbleOption() PebbleOption {
+	listener := u.EventListener()
+	return func(o *pebble.Options) {
+		o.EventListener = &listener
+	}
+}
+
+// SetInherited records a set of SST filenames that came from an ancestor
+// store restore. These are referenced in checkpoints as AncestorSSTFiles and
+// are not uploaded to the local store.
+func (u *SSTUploader) SetInherited(filenames map[string]string) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	for name, key := range filenames {
+		u.inherited[name] = key
+	}
+}
+
+// Reconcile walks pebbleDir and uploads any SST files not already in the
+// registry. Must be called after Pebble opens and before serving requests.
+func (u *SSTUploader) Reconcile(ctx context.Context) error {
+	entries, err := os.ReadDir(u.pebbleDir)
+	if err != nil {
+		return fmt.Errorf("sstuploader: readdir %q: %w", u.pebbleDir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sst") {
+			continue
+		}
+		u.mu.RLock()
+		_, inLocal := u.local[e.Name()]
+		_, inInherited := u.inherited[e.Name()]
+		u.mu.RUnlock()
+		if inLocal || inInherited {
+			continue
+		}
+		path := filepath.Join(u.pebbleDir, e.Name())
+		if err := u.uploadOne(ctx, path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Start launches the background upload goroutine. Call once; runs until ctx
+// is cancelled.
+func (u *SSTUploader) Start(ctx context.Context) {
+	go func() {
+		for {
+			select {
+			case path := <-u.uploadC:
+				go func(p string) {
+					defer u.pending.Done()
+					if err := u.uploadOne(ctx, p); err != nil {
+						logrus.Warnf("sstuploader: upload %q: %v", p, err)
+					}
+				}(path)
+			case <-ctx.Done():
+				// Signal EventListener to stop incrementing pending BEFORE we
+				// drain the channel. The write-lock ensures no EventListener
+				// call is mid-way through pending.Add when we start draining.
+				u.stopMu.Lock()
+				u.stopped = true
+				u.stopMu.Unlock()
+
+				// Drain remaining items (added before we set stopped).
+				for {
+					select {
+					case path := <-u.uploadC:
+						go func(p string) {
+							defer u.pending.Done()
+							u.uploadOne(context.Background(), p) //nolint:errcheck
+						}(path)
+					default:
+						return
+					}
+				}
+			}
+		}
+	}()
+}
+
+// Wait blocks until all in-flight and queued uploads complete. Safe to call
+// even after Start's context is cancelled — the start goroutine drains the
+// channel on exit so pending.Wait() will always unblock.
+func (u *SSTUploader) Wait() {
+	u.pending.Wait()
+}
+
+// Registry returns a snapshot of filename → s3Key for all SSTs uploaded to
+// the local store. Safe to call concurrently.
+func (u *SSTUploader) Registry() map[string]string {
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+	out := make(map[string]string, len(u.local))
+	for k, v := range u.local {
+		out[k] = v
+	}
+	return out
+}
+
+// InheritedRegistry returns a snapshot of filename → s3Key for inherited
+// (ancestor) SSTs. Safe to call concurrently.
+func (u *SSTUploader) InheritedRegistry() map[string]string {
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+	out := make(map[string]string, len(u.inherited))
+	for k, v := range u.inherited {
+		out[k] = v
+	}
+	return out
+}
+
+// uploadOne uploads path to object storage and registers it. Idempotent: if
+// the file is already in the local registry, returns immediately.
+func (u *SSTUploader) uploadOne(ctx context.Context, path string) error {
+	name := filepath.Base(path)
+
+	u.mu.RLock()
+	_, exists := u.local[name]
+	u.mu.RUnlock()
+	if exists {
+		return nil
+	}
+
+	s3Key, err := contentSSTKey(path, name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // compacted away before we could upload; safe to skip
+		}
+		return fmt.Errorf("sstuploader: hash %q: %w", name, err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // same: already compacted
+		}
+		return fmt.Errorf("sstuploader: open %q: %w", name, err)
+	}
+	defer f.Close()
+
+	if err := u.store.Put(ctx, s3Key, f); err != nil {
+		return fmt.Errorf("sstuploader: put %q: %w", s3Key, err)
+	}
+
+	u.mu.Lock()
+	u.local[name] = s3Key
+	u.mu.Unlock()
+	return nil
+}
+
+// contentSSTKey returns "sst/{first16hexOfSHA256}/{name}" for the file at path.
+func contentSSTKey(path, name string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return "sst/" + hex.EncodeToString(h.Sum(nil)[:8]) + "/" + name, nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -42,16 +42,23 @@ type Store struct {
 // terminating when the replacement starts.
 const lockRetryTimeout = 30 * time.Second
 
+// PebbleOption is a functional option for configuring pebble.Options.
+type PebbleOption = func(*pebble.Options)
+
 // Open opens (or creates) the Pebble database at dir and returns a Store.
 // The caller should call Recover to replay WAL entries before serving requests.
 //
 // If the database is locked by another process, Open retries for up to
 // lockRetryTimeout before returning an error. This handles the Kubernetes pod
 // replacement race where the old instance has not yet released the lock.
-func Open(dir string) (*Store, error) {
+func Open(dir string, extraOpts ...func(*pebble.Options)) (*Store, error) {
+	opts := &pebble.Options{}
+	for _, fn := range extraOpts {
+		fn(opts)
+	}
 	deadline := time.Now().Add(lockRetryTimeout)
 	for {
-		db, err := pebble.Open(dir, &pebble.Options{})
+		db, err := pebble.Open(dir, opts)
 		if err == nil {
 			s := &Store{db: db, notify: make(chan struct{}), closed: make(chan struct{})}
 			if err := s.loadMeta(); err != nil {

--- a/internal/wal/wal.go
+++ b/internal/wal/wal.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	DefaultSegmentMaxSize = 50 << 20 // 50 MB
-	DefaultSegmentMaxAge  = 10 * time.Second
+	DefaultSegmentMaxSize = 50 << 20        // 50 MB
+	DefaultSegmentMaxAge  = 60 * time.Second // 1 minute; controls S3 PUT frequency
 )
 
 // Uploader is called when a segment is ready to be persisted to object storage.

--- a/node.go
+++ b/node.go
@@ -138,6 +138,8 @@ type Node struct {
 
 	entriesSinceCheckpoint int64
 	checkpointTriggerC     chan struct{} // non-nil when CheckpointEntries > 0; signals entry-count-based checkpoint
+	sstUploader            *istore.SSTUploader // non-nil when ObjectStore is set; streams SSTs to S3
+
 	// bgCtx is cancelled by cancelBg — either on Close() or when fencedCheck
 	// detects that this node has been superseded as leader. When cancelled with
 	// leaderCli still nil, the node is shutting down or has been fenced; reads
@@ -165,6 +167,9 @@ func Open(cfg Config) (*Node, error) {
 		startRev int64
 		term     uint64 = 1
 	)
+	// inheritedSSTs is populated during BranchPoint restore: maps SST filename
+	// to the source store's S3 key.  Applied to the SSTUploader after open.
+	var inheritedSSTs map[string]string
 
 	// ── Restore checkpoint ───────────────────────────────────────────────────
 	switch {
@@ -197,6 +202,16 @@ func Open(cfg Config) (*Node, error) {
 			}
 			term, startRev = t, rev
 			logrus.Infof("strata: branch checkpoint restored (term=%d rev=%d)", term, startRev)
+			// Record the ancestor's SSTs so the uploader does not re-upload
+			// them; they will be referenced via AncestorSSTFiles in the index.
+			if cfg.ObjectStore != nil {
+				if idx, idxErr := checkpoint.ReadCheckpointIndex(ctx, bp.SourceStore, bp.CheckpointKey); idxErr == nil {
+					inheritedSSTs = make(map[string]string, len(idx.SSTFiles))
+					for _, key := range idx.SSTFiles {
+						inheritedSSTs[filepath.Base(key)] = key
+					}
+				}
+			}
 		}
 	case cfg.ObjectStore != nil:
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -243,9 +258,28 @@ func Open(cfg Config) (*Node, error) {
 	}
 
 	// ── Open Pebble ──────────────────────────────────────────────────────────
-	db, err := istore.Open(pebbleDir)
+	// Create the SST uploader before opening Pebble so its EventListener is
+	// active from the first flush/compaction. Only used when S3 is configured.
+	var sstUp *istore.SSTUploader
+	var pebbleOpts []istore.PebbleOption
+	if cfg.ObjectStore != nil {
+		sstUp = istore.NewSSTUploader(cfg.ObjectStore, pebbleDir)
+		pebbleOpts = append(pebbleOpts, sstUp.PebbleOption())
+	}
+
+	db, err := istore.Open(pebbleDir, pebbleOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("strata: open store: %w", err)
+	}
+	if sstUp != nil {
+		if len(inheritedSSTs) > 0 {
+			sstUp.SetInherited(inheritedSSTs)
+		}
+		reconcileCtx, reconcileCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer reconcileCancel()
+		if err := sstUp.Reconcile(reconcileCtx); err != nil {
+			logrus.Warnf("strata: SST reconcile: %v", err)
+		}
 	}
 	// Always derive startRev from pebble's actual revision, not the checkpoint
 	// header. A Compact entry does not write a pebble log key, so after a
@@ -385,10 +419,17 @@ func Open(cfg Config) (*Node, error) {
 				}
 			}
 			_ = newRev // term drives WAL open; startRev is read from Pebble below
-			freshDB, rerr := istore.Open(pebbleDir)
+			freshDB, rerr := istore.Open(pebbleDir, pebbleOpts...)
 			if rerr != nil {
 				w.Close()
 				return nil, fmt.Errorf("strata: reopen store after GC-gap fix: %w", rerr)
+			}
+			if sstUp != nil {
+				reconcileCtx, reconcileCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+				defer reconcileCancel()
+				if err := sstUp.Reconcile(reconcileCtx); err != nil {
+					logrus.Warnf("strata: SST reconcile after GC-gap fix: %v", err)
+				}
 			}
 			w.Close()
 			freshW, rerr := wal.Open(walDir, newTerm, freshDB.CurrentRevision()+1, opts...)
@@ -403,15 +444,16 @@ func Open(cfg Config) (*Node, error) {
 
 	bgCtx, bgCancel := context.WithCancel(context.Background())
 	n := &Node{
-		cfg:      cfg,
-		term:     term,
-		db:       db,
-		wal:      w,
-		bgCtx:    bgCtx,
-		cancelBg: bgCancel,
-		nextRev:  db.CurrentRevision(),
-		pending:  make(map[string]pendingKV),
-		writeC:   make(chan *writeReq, 1024),
+		cfg:         cfg,
+		term:        term,
+		db:          db,
+		wal:         w,
+		bgCtx:       bgCtx,
+		cancelBg:    bgCancel,
+		nextRev:     db.CurrentRevision(),
+		pending:     make(map[string]pendingKV),
+		writeC:      make(chan *writeReq, 1024),
+		sstUploader: sstUp,
 	}
 	if cfg.CheckpointEntries > 0 {
 		n.checkpointTriggerC = make(chan struct{}, 1)
@@ -443,6 +485,16 @@ func Open(cfg Config) (*Node, error) {
 	if n.loadRole() == roleFollower {
 		n.bgWg.Add(1)
 		go func() { defer n.bgWg.Done(); n.followLoop(bgCtx) }()
+	}
+	// Only start background SST uploads on leader/single nodes. Followers
+	// should not upload their SSTs to S3: the leader's GCOrphanSSTs would
+	// delete them (they aren't referenced by any checkpoint), and when the
+	// follower later becomes the leader its checkpoint would reference missing
+	// keys. Instead, the follower-to-leader promotion path calls Reconcile
+	// (see attemptPromotion) to upload all current SSTs before the first
+	// checkpoint.
+	if sstUp != nil && n.loadRole() != roleFollower {
+		sstUp.Start(bgCtx)
 	}
 
 	// ── Observability ─────────────────────────────────────────────────────────
@@ -955,6 +1007,28 @@ func (n *Node) attemptPromotion(bgCtx context.Context, lock *election.Lock, grac
 		if err := n.becomeLeader(bgCtx, lock, rec); err != nil {
 			logrus.Errorf("strata: promotion failed: %v", err)
 			return nil, false
+		}
+		// Upload any SSTs that exist on disk but aren't in S3 yet. The
+		// follower didn't run SSTUploader.Start(), so its SSTs were never
+		// streamed. Additionally, becomeLeader may have restored from a
+		// checkpoint and replayed WAL, creating new SST files. Reconcile
+		// ensures all of them are in S3 before the first checkpoint.
+		if n.sstUploader != nil {
+			rCtx, rCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			if rErr := n.sstUploader.Reconcile(rCtx); rErr != nil {
+				logrus.Warnf("strata: promoted leader SST reconcile: %v", rErr)
+			}
+			rCancel()
+			n.sstUploader.Start(bgCtx)
+		}
+		// Write a checkpoint immediately after Reconcile so that all
+		// uploaded SSTs are referenced by a live checkpoint. Without this,
+		// the old leader's GCOrphanSSTs could delete the just-uploaded SSTs
+		// before the checkpointLoop gets a chance to write its startup
+		// checkpoint. The checkpointLoop's own forceCheckpoint is redundant
+		// but harmless (same rev → same checkpoint key → idempotent overwrite).
+		if n.cfg.ObjectStore != nil && n.cfg.CheckpointInterval > 0 {
+			n.forceCheckpoint(bgCtx)
 		}
 		n.bgWg.Add(1)
 		go func() { defer n.bgWg.Done(); n.commitLoop(bgCtx) }()
@@ -1911,7 +1985,14 @@ func (n *Node) forceCheckpoint(ctx context.Context) {
 		logrus.Errorf("strata: startup checkpoint flush pebble: %v", err)
 		return
 	}
-	if err := checkpoint.Write(ctx, n.db.Pebble(), n.cfg.ObjectStore, n.term, rev, "", n.cfg.AncestorStore); err != nil {
+	if n.sstUploader != nil {
+		n.sstUploader.Wait()
+		if err := checkpoint.WriteWithRegistry(ctx, n.db.Pebble(), n.cfg.ObjectStore, n.term, rev, "", n.sstUploader.Registry(), n.sstUploader.InheritedRegistry()); err != nil {
+			n.fenceMu.Unlock()
+			logrus.Errorf("strata: startup checkpoint rev=%d: %v", rev, err)
+			return
+		}
+	} else if err := checkpoint.Write(ctx, n.db.Pebble(), n.cfg.ObjectStore, n.term, rev, "", n.cfg.AncestorStore); err != nil {
 		n.fenceMu.Unlock()
 		logrus.Errorf("strata: startup checkpoint rev=%d: %v", rev, err)
 		return
@@ -1942,7 +2023,14 @@ func (n *Node) maybeCheckpoint(ctx context.Context) {
 		logrus.Errorf("strata: checkpoint flush pebble: %v", err)
 		return
 	}
-	if err := checkpoint.Write(ctx, n.db.Pebble(), n.cfg.ObjectStore, n.term, rev, "", n.cfg.AncestorStore); err != nil {
+	if n.sstUploader != nil {
+		n.sstUploader.Wait()
+		if err := checkpoint.WriteWithRegistry(ctx, n.db.Pebble(), n.cfg.ObjectStore, n.term, rev, "", n.sstUploader.Registry(), n.sstUploader.InheritedRegistry()); err != nil {
+			n.fenceMu.Unlock()
+			logrus.Errorf("strata: write checkpoint rev=%d: %v", rev, err)
+			return
+		}
+	} else if err := checkpoint.Write(ctx, n.db.Pebble(), n.cfg.ObjectStore, n.term, rev, "", n.cfg.AncestorStore); err != nil {
 		n.fenceMu.Unlock()
 		logrus.Errorf("strata: write checkpoint rev=%d: %v", rev, err)
 		return
@@ -1975,18 +2063,29 @@ func (n *Node) maybeCheckpoint(ctx context.Context) {
 	// GC old checkpoint archives from S3, keeping the 2 most recent so that
 	// any in-flight bootstrap that read manifest/latest just before we
 	// overwrote it can still fetch the previous checkpoint.
-	cpDeleted, cpGCErr := checkpoint.GCCheckpoints(gcCtx, n.cfg.ObjectStore, 2)
+	// GCCheckpoints deletes old checkpoint archives and returns the set of SST
+	// keys that were exclusively referenced by the deleted checkpoints. Passing
+	// that candidate set to GCOrphanSSTs (instead of listing all "sst/" keys)
+	// eliminates the race where a newly-promoted leader uploads SSTs before
+	// writing its first checkpoint — those SSTs never appear in any deleted
+	// checkpoint's index, so they are never mistakenly treated as orphans.
+	cpDeleted, orphanSSTs, cpGCErr := checkpoint.GCCheckpoints(gcCtx, n.cfg.ObjectStore, 2)
 	if cpGCErr != nil {
 		logrus.Warnf("strata: checkpoint gc: %v", cpGCErr)
 	} else if cpDeleted > 0 {
 		logrus.Infof("strata: checkpoint gc: deleted %d old checkpoint(s)", cpDeleted)
 	}
 
-	sstDeleted, sstGCErr := checkpoint.GCOrphanSSTs(gcCtx, n.cfg.ObjectStore)
-	if sstGCErr != nil {
-		logrus.Warnf("strata: sst gc: %v", sstGCErr)
-	} else if sstDeleted > 0 {
-		logrus.Infof("strata: sst gc: deleted %d orphan sst(s)", sstDeleted)
+	// Only run SST GC when old checkpoints were actually deleted and there are
+	// candidate SSTs to clean up. This skips the Delete loop entirely when
+	// nothing changed, which is the common case.
+	if cpDeleted > 0 && len(orphanSSTs) > 0 {
+		sstDeleted, sstGCErr := checkpoint.GCOrphanSSTs(gcCtx, n.cfg.ObjectStore, orphanSSTs)
+		if sstGCErr != nil {
+			logrus.Warnf("strata: sst gc: %v", sstGCErr)
+		} else if sstDeleted > 0 {
+			logrus.Infof("strata: sst gc: deleted %d orphan sst(s)", sstDeleted)
+		}
 	}
 }
 


### PR DESCRIPTION
replace the global-LIST approach with a candidate-set approach. GCCheckpoints now also collects SSTs from the checkpoints it deletes, excluding SSTs still referenced by surviving checkpoints. GCOrphanSSTs accepts that pre-computed candidate set and deletes only those objects.
