### PR TITLE
fix: start commitLoop before Reconcile/forceCheckpoint on leader promotion

### DIFF
--- a/node.go
+++ b/node.go
@@ -1025,6 +1025,17 @@ func (n *Node) attemptPromotion(bgCtx context.Context, lock *election.Lock, grac
 			logrus.Errorf("strata: promotion failed: %v", err)
 			return nil, false
 		}
+		// Start write-processing loops immediately so that client writes are
+		// not blocked while we run Reconcile and the startup checkpoint below.
+		// forceCheckpoint (and periodic maybeCheckpoint) already hold
+		// fenceMu.Lock() during I/O, which briefly pauses new writes — that
+		// is the same behaviour as during a normal checkpoint interval.
+		n.bgWg.Add(1)
+		go func() { defer n.bgWg.Done(); n.commitLoop(bgCtx) }()
+		if n.cfg.ObjectStore != nil && n.cfg.CheckpointInterval > 0 {
+			n.bgWg.Add(1)
+			go func() { defer n.bgWg.Done(); n.checkpointLoop(bgCtx) }()
+		}
 		// Upload any SSTs that exist on disk but aren't in S3 yet. The
 		// follower didn't run SSTUploader.Start(), so its SSTs were never
 		// streamed. Additionally, becomeLeader may have restored from a
@@ -1046,12 +1057,6 @@ func (n *Node) attemptPromotion(bgCtx context.Context, lock *election.Lock, grac
 		// but harmless (same rev → same checkpoint key → idempotent overwrite).
 		if n.cfg.ObjectStore != nil && n.cfg.CheckpointInterval > 0 {
 			n.forceCheckpoint(bgCtx)
-		}
-		n.bgWg.Add(1)
-		go func() { defer n.bgWg.Done(); n.commitLoop(bgCtx) }()
-		if n.cfg.ObjectStore != nil && n.cfg.CheckpointInterval > 0 {
-			n.bgWg.Add(1)
-			go func() { defer n.bgWg.Done(); n.checkpointLoop(bgCtx) }()
 		}
 		return nil, true
 	}


### PR DESCRIPTION
Previously, commitLoop only started AFTER Reconcile and forceCheckpoint completed. On slow CI runners (Ubuntu + -race), Reconcile + forceCheckpoint could take 70-100s. Meanwhile, IsLeader() returned true immediately after becomeLeader(), so test clients could call Put() — which sends to the buffered writeC channel and then awaits on req.done. Since commitLoop hadn't started yet, the await blocked until the 120s context expired.

Fix: start commitLoop (and checkpointLoop) immediately after becomeLeader() returns, before Reconcile and forceCheckpoint. The forceCheckpoint already holds fenceMu.Lock() during all I/O, briefly pausing new writes — exactly the same behaviour as periodic maybeCheckpoint. Writes that arrive before fenceMu is taken are processed normally by the now-running commitLoop.

Fixes TestE2EThreeNode flakiness on Ubuntu CI.