### PR TITLE
docs: update architecture, operations, and configuration docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,6 +101,8 @@ SST files are stored at `sst/<hash16>/<name>` where `<hash16>` is the first 16 h
 - **Deduplication across checkpoints**: an SST that did not change between two checkpoints is uploaded once.
 - **Safe sharing across nodes**: multiple nodes restoring from the same checkpoint may produce SST files with the same Pebble filename but different content (due to non-deterministic WAL replay flush boundaries). Content addressing ensures they never collide.
 
+> **Implementation note:** Pebble fires a `TableCreated` event when an SST file is first created (while it is still empty). The uploader ignores 0-byte SST files during `Reconcile` to avoid registering an empty file in the content registry and silently skipping the real upload that follows when the flush or compaction completes.
+
 ---
 
 ## Leader election
@@ -150,6 +152,14 @@ Followers connect to the leader's gRPC peer address and open a **bidirectional**
 **Quorum ACK:** after fsyncing each entry to its local WAL and applying it to Pebble, a follower sends an ACK with the entry's revision back to the leader. The leader waits for ACKs from all connected followers before applying the batch to its own Pebble. This guarantees that every acknowledged write exists on at least two nodes' WALs.
 
 **Catch-up on connect:** when a follower connects, it sends its current revision. The leader replays from that revision using its in-memory ring buffer (`PeerBufferSize` entries, default 10 000). If the follower is too far behind (ring buffer miss), the leader returns `ErrResyncRequired` and the follower restores the latest S3 checkpoint then replays remaining WAL entries from S3.
+
+A full resync can be triggered by three conditions, each tracked in the `strata_follower_resyncs_total` metric:
+
+| `reason` label | When it fires |
+|---|---|
+| `behind_leader_start` | The follower's applied revision is behind the leader's own starting revision — it cannot replay missing entries from the ring buffer because the leader itself began at a higher point |
+| `ring_buffer_miss` | The follower's requested revision is older than the oldest entry in the ring buffer — it fell too far behind while connected |
+| `stream_gap` | A revision discontinuity was detected mid-stream — the follower missed entries and must restore from a checkpoint |
 
 **Write forwarding:** a client write arriving at a follower is forwarded to the leader via gRPC. The follower returns the leader's response (including the assigned revision) directly to the client.
 
@@ -209,3 +219,14 @@ Entries are stored at `branches/<id>` in the source store as JSON:
 - **Watchers** are registered in a fan-out broadcaster that sends events after each write. Each watcher runs in its own goroutine.
 - **WAL background goroutines** (rotation loop, upload loop) share the WAL mutex with write operations but hold it only briefly during segment rotation.
 - **Follower streams** each run in a dedicated goroutine; the leader pushes entries from a per-follower buffered channel.
+
+---
+
+## Follower promotion sequence
+
+When a follower wins a takeover election, it goes through the following steps in order:
+
+1. **`becomeLeader`** — reopens the WAL for writing, loads the latest S3 checkpoint, and replays any WAL segments ahead of the checkpoint. `IsLeader()` becomes `true` at the end of this step.
+2. **Start `commitLoop` and `checkpointLoop`** — these goroutines are started immediately so that client writes queued in the `writeC` channel are processed right away. Without this, writes would stall until steps 3–4 finish.
+3. **`Reconcile`** — uploads any SST files that exist on disk but were never streamed to S3 (followers don't run the SST uploader). `forceCheckpoint` takes a `fenceMu` write-lock during all I/O, briefly pausing new writes — the same behaviour as periodic checkpoints.
+4. **`forceCheckpoint`** — writes a startup checkpoint that references all local SSTs, ensuring the next GC cycle on the old leader cannot delete them before they are named in a live checkpoint.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,7 @@
 | `PeerServerTLS` | `credentials.TransportCredentials` | `nil` | mTLS credentials for the peer gRPC server (leader side). |
 | `PeerClientTLS` | `credentials.TransportCredentials` | `nil` | mTLS credentials for the peer gRPC client (follower side). |
 | `MetricsAddr` | `string` | `""` | HTTP address for `/metrics`, `/healthz`, `/readyz`. Empty = disabled. |
+| `ReadConsistency` | `ReadConsistency` | `"linearizable"` | Consistency guarantee for reads served by the etcd adapter. `"linearizable"` (default): each read syncs to the leader's current revision before returning, ensuring no stale reads. `"serializable"`: reads are served from local Pebble state without a round-trip to the leader; lower latency but may return slightly stale data on followers. |
 
 ### Using a custom S3-compatible store
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -166,7 +166,7 @@ Client TLS and peer mTLS are independent — each uses its own cert/key/CA and c
 
 ## Authentication and RBAC
 
-Strata implements the etcd v3 Auth API: username/password authentication with bearer tokens, and role-based access control scoped to key prefixes. Auth state (users, roles, enabled flag) is stored in Pebble and flows through the WAL, so it is replicated to followers and included in S3 checkpoints.
+Strata implements the etcd v3 Auth API: username/password authentication with bearer tokens, and role-based access control scoped to key prefixes. Auth state (users, roles, enabled flag) is stored in Pebble and flows through the WAL, so it is replicated to followers and included in S3 checkpoints. Bearer tokens are persisted to Pebble and survive node restarts — clients do not need to re-authenticate after a restart.
 
 Enable auth with `--auth-enabled`:
 
@@ -288,6 +288,15 @@ The `root` role always passes all checks regardless of the key.
 
 Keys under the `\x00auth/` prefix are reserved for internal auth storage. Access to these keys via the KV service is blocked for all users, including `root`. Attempting to read or write them returns `PermissionDenied`.
 
+### Rate limiting
+
+To protect against brute-force attacks, Strata enforces a per-username rate limit on failed authentication attempts:
+
+- **5 consecutive failures** within a **5-minute window** triggers a **15-minute lockout** for that username.
+- Subsequent `Authenticate` calls during the lockout period return an error without checking the password.
+- The lockout state is in-memory only and resets on node restart (intentional: a restart is already a privileged operation).
+- All authentication outcomes are recorded in the `strata_auth_attempts_total` metric with a `result` label (`success`, `fail`, `locked`).
+
 ### Disabling auth
 
 ```bash
@@ -347,6 +356,8 @@ strata run --metrics-addr 0.0.0.0:9090 ...
 | `strata_wal_gc_segments_total` | counter | — | WAL segments deleted from S3 after checkpointing |
 | `strata_checkpoints_total` | counter | — | Checkpoints written to S3 |
 | `strata_elections_total` | counter | `outcome` | Election attempts (`won`/`lost`) |
+| `strata_follower_resyncs_total` | counter | `reason` | Full resync events triggered on followers (`behind_leader_start` / `ring_buffer_miss` / `stream_gap`) |
+| `strata_auth_attempts_total` | counter | `result` | Authentication attempts (`success` / `fail` / `locked`) |
 
 `op` label values: `put`, `create`, `update`, `delete`, `compact`.
 

--- a/website/src/content/docs/architecture.md
+++ b/website/src/content/docs/architecture.md
@@ -2,6 +2,7 @@
 title: Architecture
 description: Internals — WAL, checkpoints, leader election, replication, and branching.
 ---
+
 # Architecture
 
 ## Overview
@@ -105,6 +106,8 @@ SST files are stored at `sst/<hash16>/<name>` where `<hash16>` is the first 16 h
 - **Deduplication across checkpoints**: an SST that did not change between two checkpoints is uploaded once.
 - **Safe sharing across nodes**: multiple nodes restoring from the same checkpoint may produce SST files with the same Pebble filename but different content (due to non-deterministic WAL replay flush boundaries). Content addressing ensures they never collide.
 
+> **Implementation note:** Pebble fires a `TableCreated` event when an SST file is first created (while it is still empty). The uploader ignores 0-byte SST files during `Reconcile` to avoid registering an empty file in the content registry and silently skipping the real upload that follows when the flush or compaction completes.
+
 ---
 
 ## Leader election
@@ -154,6 +157,14 @@ Followers connect to the leader's gRPC peer address and open a **bidirectional**
 **Quorum ACK:** after fsyncing each entry to its local WAL and applying it to Pebble, a follower sends an ACK with the entry's revision back to the leader. The leader waits for ACKs from all connected followers before applying the batch to its own Pebble. This guarantees that every acknowledged write exists on at least two nodes' WALs.
 
 **Catch-up on connect:** when a follower connects, it sends its current revision. The leader replays from that revision using its in-memory ring buffer (`PeerBufferSize` entries, default 10 000). If the follower is too far behind (ring buffer miss), the leader returns `ErrResyncRequired` and the follower restores the latest S3 checkpoint then replays remaining WAL entries from S3.
+
+A full resync can be triggered by three conditions, each tracked in the `strata_follower_resyncs_total` metric:
+
+| `reason` label | When it fires |
+|---|---|
+| `behind_leader_start` | The follower's applied revision is behind the leader's own starting revision — it cannot replay missing entries from the ring buffer because the leader itself began at a higher point |
+| `ring_buffer_miss` | The follower's requested revision is older than the oldest entry in the ring buffer — it fell too far behind while connected |
+| `stream_gap` | A revision discontinuity was detected mid-stream — the follower missed entries and must restore from a checkpoint |
 
 **Write forwarding:** a client write arriving at a follower is forwarded to the leader via gRPC. The follower returns the leader's response (including the assigned revision) directly to the client.
 
@@ -213,3 +224,14 @@ Entries are stored at `branches/<id>` in the source store as JSON:
 - **Watchers** are registered in a fan-out broadcaster that sends events after each write. Each watcher runs in its own goroutine.
 - **WAL background goroutines** (rotation loop, upload loop) share the WAL mutex with write operations but hold it only briefly during segment rotation.
 - **Follower streams** each run in a dedicated goroutine; the leader pushes entries from a per-follower buffered channel.
+
+---
+
+## Follower promotion sequence
+
+When a follower wins a takeover election, it goes through the following steps in order:
+
+1. **`becomeLeader`** — reopens the WAL for writing, loads the latest S3 checkpoint, and replays any WAL segments ahead of the checkpoint. `IsLeader()` becomes `true` at the end of this step.
+2. **Start `commitLoop` and `checkpointLoop`** — these goroutines are started immediately so that client writes queued in the `writeC` channel are processed right away. Without this, writes would stall until steps 3–4 finish.
+3. **`Reconcile`** — uploads any SST files that exist on disk but were never streamed to S3 (followers don't run the SST uploader). `forceCheckpoint` takes a `fenceMu` write-lock during all I/O, briefly pausing new writes — the same behaviour as periodic checkpoints.
+4. **`forceCheckpoint`** — writes a startup checkpoint that references all local SSTs, ensuring the next GC cycle on the old leader cannot delete them before they are named in a live checkpoint.

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -2,6 +2,7 @@
 title: Configuration
 description: All strata.Config fields and CLI flags for the Strata standalone binary.
 ---
+
 # Configuration Reference
 
 ## Library: `strata.Config`
@@ -28,6 +29,7 @@ description: All strata.Config fields and CLI flags for the Strata standalone bi
 | `PeerServerTLS` | `credentials.TransportCredentials` | `nil` | mTLS credentials for the peer gRPC server (leader side). |
 | `PeerClientTLS` | `credentials.TransportCredentials` | `nil` | mTLS credentials for the peer gRPC client (follower side). |
 | `MetricsAddr` | `string` | `""` | HTTP address for `/metrics`, `/healthz`, `/readyz`. Empty = disabled. |
+| `ReadConsistency` | `ReadConsistency` | `"linearizable"` | Consistency guarantee for reads served by the etcd adapter. `"linearizable"` (default): each read syncs to the leader's current revision before returning, ensuring no stale reads. `"serializable"`: reads are served from local Pebble state without a round-trip to the leader; lower latency but may return slightly stale data on followers. |
 
 ### Using a custom S3-compatible store
 

--- a/website/src/content/docs/operations.md
+++ b/website/src/content/docs/operations.md
@@ -2,6 +2,7 @@
 title: Operations Guide
 description: Deploy Strata in production — multi-node clusters, TLS, auth, observability, branching, and disaster recovery.
 ---
+
 # Operations Guide
 
 ## Single-node with S3
@@ -170,7 +171,7 @@ Client TLS and peer mTLS are independent — each uses its own cert/key/CA and c
 
 ## Authentication and RBAC
 
-Strata implements the etcd v3 Auth API: username/password authentication with bearer tokens, and role-based access control scoped to key prefixes. Auth state (users, roles, enabled flag) is stored in Pebble and flows through the WAL, so it is replicated to followers and included in S3 checkpoints.
+Strata implements the etcd v3 Auth API: username/password authentication with bearer tokens, and role-based access control scoped to key prefixes. Auth state (users, roles, enabled flag) is stored in Pebble and flows through the WAL, so it is replicated to followers and included in S3 checkpoints. Bearer tokens are persisted to Pebble and survive node restarts — clients do not need to re-authenticate after a restart.
 
 Enable auth with `--auth-enabled`:
 
@@ -292,6 +293,15 @@ The `root` role always passes all checks regardless of the key.
 
 Keys under the `\x00auth/` prefix are reserved for internal auth storage. Access to these keys via the KV service is blocked for all users, including `root`. Attempting to read or write them returns `PermissionDenied`.
 
+### Rate limiting
+
+To protect against brute-force attacks, Strata enforces a per-username rate limit on failed authentication attempts:
+
+- **5 consecutive failures** within a **5-minute window** triggers a **15-minute lockout** for that username.
+- Subsequent `Authenticate` calls during the lockout period return an error without checking the password.
+- The lockout state is in-memory only and resets on node restart (intentional: a restart is already a privileged operation).
+- All authentication outcomes are recorded in the `strata_auth_attempts_total` metric with a `result` label (`success`, `fail`, `locked`).
+
 ### Disabling auth
 
 ```bash
@@ -351,6 +361,8 @@ strata run --metrics-addr 0.0.0.0:9090 ...
 | `strata_wal_gc_segments_total` | counter | — | WAL segments deleted from S3 after checkpointing |
 | `strata_checkpoints_total` | counter | — | Checkpoints written to S3 |
 | `strata_elections_total` | counter | `outcome` | Election attempts (`won`/`lost`) |
+| `strata_follower_resyncs_total` | counter | `reason` | Full resync events triggered on followers (`behind_leader_start` / `ring_buffer_miss` / `stream_gap`) |
+| `strata_auth_attempts_total` | counter | `result` | Authentication attempts (`success` / `fail` / `locked`) |
 
 `op` label values: `put`, `create`, `update`, `delete`, `compact`.
 


### PR DESCRIPTION
- operations.md: add auth rate limiting section (5 failures/5min → 15min lockout); note token persistence survives restarts; add missing metrics strata_auth_attempts_total and strata_follower_resyncs_total to the Prometheus metrics table
- architecture.md: add 0-byte SST filter note in Content-addressed SSTs; expand follower catch-up section with all three resync triggers (table); add Follower promotion sequence section documenting commitLoop-first startup order
- configuration.md: add ReadConsistency field (linearizable / serializable)

All changes mirrored to website/src/content/docs/.