### PR TITLE
feat: encryption at rest with AES-256-GCM

### DIFF
--- a/cmd/strata/main.go
+++ b/cmd/strata/main.go
@@ -2,9 +2,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"os"
@@ -220,6 +223,9 @@ func runCmd() *cobra.Command {
 		branchSourcePrefix   string
 		branchSourceEndpoint string
 		branchCheckpoint     string
+		// encryption
+		encryptionKeyFile string
+		encryptionKeyEnv  string
 	)
 
 	cmd := &cobra.Command{
@@ -325,6 +331,15 @@ func runCmd() *cobra.Command {
 				cfg.AncestorStore = sourceStore
 				logrus.Infof("branch node: source bucket %q prefix %q checkpoint %q",
 					branchSourceBucket, branchSourcePrefix, branchCheckpoint)
+			}
+
+			if encryptionKeyFile != "" || encryptionKeyEnv != "" {
+				kp, err := loadEncryptionKey(encryptionKeyFile, encryptionKeyEnv)
+				if err != nil {
+					return fmt.Errorf("encryption key: %w", err)
+				}
+				cfg.Encryption = &strata.EncryptionConfig{KeyProvider: kp}
+				logrus.Info("encryption at rest enabled (AES-256-GCM)")
 			}
 
 			node, err := strata.Open(cfg)
@@ -437,6 +452,9 @@ func runCmd() *cobra.Command {
 	cmd.Flags().StringVar(&branchSourcePrefix, "branch-source-prefix", "", "S3 key prefix of the source node")
 	cmd.Flags().StringVar(&branchSourceEndpoint, "branch-source-endpoint", "", "custom S3 endpoint for the source store")
 	cmd.Flags().StringVar(&branchCheckpoint, "branch-checkpoint", "", "checkpoint index key returned by 'strata branch fork' (required with --branch-source-bucket)")
+	// encryption
+	cmd.Flags().StringVar(&encryptionKeyFile, "encryption-key-file", "", "path to file containing a 32-byte AES-256 key (raw, hex, or base64)")
+	cmd.Flags().StringVar(&encryptionKeyEnv, "encryption-key-env", "", "environment variable holding a base64-encoded 32-byte AES-256 key")
 
 	return cmd
 }
@@ -604,4 +622,54 @@ func newS3Store(ctx context.Context, bucket, prefix, endpoint string) (*object.S
 	}
 	client := s3.NewFromConfig(awsCfg, clientOpts...)
 	return object.NewS3Store(client, bucket, prefix), nil
+}
+
+// loadEncryptionKey reads a 32-byte AES-256 key from a file or an environment
+// variable. The key may be raw bytes (32), lowercase hex (64 chars), or
+// standard base64 (44 chars). keyFile takes precedence over keyEnv.
+func loadEncryptionKey(keyFile, keyEnv string) (*object.StaticKeyProvider, error) {
+	var raw []byte
+
+	if keyFile != "" {
+		data, err := os.ReadFile(keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("read key file: %w", err)
+		}
+		raw = bytes.TrimSpace(data)
+	} else {
+		val := os.Getenv(keyEnv)
+		if val == "" {
+			return nil, fmt.Errorf("environment variable %q is empty or not set", keyEnv)
+		}
+		raw = []byte(val)
+	}
+
+	decoded, err := decodeKeyMaterial(raw)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewStaticKeyProvider(decoded)
+}
+
+// decodeKeyMaterial decodes a key from raw bytes, lowercase hex (64 chars), or
+// standard base64 (44 chars). Returns an error for any other length or format.
+func decodeKeyMaterial(raw []byte) ([]byte, error) {
+	switch len(raw) {
+	case 32:
+		return raw, nil
+	case 64:
+		dst := make([]byte, 32)
+		if _, err := hex.Decode(dst, raw); err != nil {
+			return nil, fmt.Errorf("hex key: %w", err)
+		}
+		return dst, nil
+	case 44:
+		dst, err := base64.StdEncoding.DecodeString(string(raw))
+		if err != nil {
+			return nil, fmt.Errorf("base64 key: %w", err)
+		}
+		return dst, nil
+	default:
+		return nil, fmt.Errorf("key must be 32 raw bytes, 64 hex chars, or 44 base64 chars; got %d bytes", len(raw))
+	}
 }

--- a/config.go
+++ b/config.go
@@ -167,6 +167,24 @@ type Config struct {
 	// MetricsAddr is the TCP address for the Prometheus /metrics, /healthz,
 	// and /readyz HTTP endpoints (e.g. "0.0.0.0:9090"). Empty means disabled.
 	MetricsAddr string
+
+	// ── Encryption ────────────────────────────────────────────────────────────
+
+	// Encryption, if non-nil, enables AES-256-GCM encryption for all data
+	// written to and read from the object store (WAL segments, SST files,
+	// checkpoint manifests). Local Pebble files on disk are not encrypted.
+	//
+	// Use [object.NewStaticKeyProvider] for a fixed 32-byte key loaded at
+	// startup. The KeyProvider interface is designed to be extended with KMS
+	// backends in a future release.
+	Encryption *EncryptionConfig
+}
+
+// EncryptionConfig holds encryption settings for a Node.
+type EncryptionConfig struct {
+	// KeyProvider supplies the AES-256 key used to encrypt/decrypt all objects
+	// in the object store. Must not be nil when Encryption is set.
+	KeyProvider object.KeyProvider
 }
 
 func (c *Config) setDefaults() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -211,6 +211,30 @@ Entries are stored at `branches/<id>` in the source store as JSON:
 
 ---
 
+## Encryption at rest
+
+When `Config.Encryption` is set, Strata wraps the `object.Store` with an `EncryptedStore` at startup. Every object written to or read from the store (WAL segments, SST files, checkpoint indices, manifests, leader-lock) is transparently encrypted and decrypted — no changes are required in the WAL, SST uploader, or checkpoint code.
+
+**Algorithm:** AES-256-GCM (AEAD — provides both confidentiality and integrity).
+
+**Per-object wire format (chunked streaming, 64 KiB chunks):**
+
+```
+[1: version=0x01][1: keyID][12: fileNonce]
+repeated: [4: chunkPlainLen uint32 BE][chunkPlainLen+16: ciphertext+GCM tag]
+end:       [4: 0x00000000]
+```
+
+Each object gets a fresh 12-byte random `fileNonce`. Per-chunk nonces are derived by XOR-ing the last 8 bytes of the file nonce with the chunk index, ensuring every (file, chunk) pair has a unique nonce. Overhead is 30 bytes per object plus 16 bytes (GCM tag) per 64 KiB chunk.
+
+**Content-addressed SST deduplication is preserved.** SST keys are `sst/{hash16-of-plaintext}/{name}` — the hash is computed from the *plaintext* before upload. The encrypted ciphertext stored at that key differs per upload (different random nonce), but the key still identifies the content, so duplicate-detection ("does this key already exist?") works correctly.
+
+**Optional interface propagation.** `EncryptedStore` delegates `ConditionalStore` (leader election CAS) and `VersionedStore` (point-in-time restore) to the inner store, encrypting/decrypting only the object body while leaving ETag and version-ID semantics unchanged.
+
+**Scope.** S3 objects only. Local Pebble files are not encrypted in V1. A future `EncryptedFS` (`vfs.FS` wrapper for Pebble) is planned.
+
+---
+
 ## Concurrency model
 
 - **Revision assignment** is serialised under `node.mu`. This keeps the revision counter monotonic.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,13 @@
 | `PeerClientTLS` | `credentials.TransportCredentials` | `nil` | mTLS credentials for the peer gRPC client (follower side). |
 | `MetricsAddr` | `string` | `""` | HTTP address for `/metrics`, `/healthz`, `/readyz`. Empty = disabled. |
 | `ReadConsistency` | `ReadConsistency` | `"linearizable"` | Consistency guarantee for reads served by the etcd adapter. `"linearizable"` (default): each read syncs to the leader's current revision before returning, ensuring no stale reads. `"serializable"`: reads are served from local Pebble state without a round-trip to the leader; lower latency but may return slightly stale data on followers. |
+| `Encryption` | `*EncryptionConfig` | `nil` | When non-nil, enables AES-256-GCM encryption for all data written to and read from the object store (WAL segments, SST files, checkpoints, manifests). Local Pebble files on disk are not encrypted. See [Encryption at rest](operations.md#encryption-at-rest). |
+
+### `EncryptionConfig`
+
+| Field | Type | Description |
+|---|---|---|
+| `KeyProvider` | `object.KeyProvider` | Supplies the 32-byte AES-256 key. Use `object.NewStaticKeyProvider(key)` for a fixed key loaded at startup. The interface is designed for future KMS backends. |
 
 ### Using a custom S3-compatible store
 
@@ -92,6 +99,8 @@ strata run [flags]
 | `--auth-enabled` | `false` | Enable etcd-compatible authentication and RBAC |
 | `--token-ttl` | `300` | Bearer token lifetime in seconds |
 | `--metrics-addr` | — | HTTP address for metrics and health endpoints |
+| `--encryption-key-file` | — | Path to file containing a 32-byte AES-256 key (raw, hex-encoded, or base64-encoded). Enables encryption at rest for all S3 objects. |
+| `--encryption-key-env` | — | Environment variable holding a base64-encoded 32-byte AES-256 key. Alternative to `--encryption-key-file`. |
 | `--branch-source-bucket` | — | S3 bucket of the source database (branch nodes only) |
 | `--branch-source-prefix` | — | S3 prefix of the source database (branch nodes only) |
 | `--branch-source-endpoint` | — | S3 endpoint of the source database (branch nodes only) |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -324,6 +324,74 @@ etcdctl --user svc-account:pass get /secrets/key         # PermissionDenied
 
 ---
 
+## Encryption at rest
+
+Strata can encrypt all data written to the object store (WAL segments, SST files, checkpoints, and manifests) using AES-256-GCM. Each object is encrypted with a unique random nonce; the authentication tag provides integrity verification on every read. Local Pebble files on disk are not encrypted.
+
+### Enabling encryption
+
+Generate a 32-byte key and store it securely:
+
+```bash
+# Generate a random key and save it (base64-encoded)
+openssl rand -base64 32 > /etc/strata/encryption.key
+chmod 600 /etc/strata/encryption.key
+```
+
+Pass the key file to the node:
+
+```bash
+strata run \
+  --data-dir /var/lib/strata \
+  --s3-bucket my-bucket      \
+  --encryption-key-file /etc/strata/encryption.key
+```
+
+Alternatively, supply the key via an environment variable:
+
+```bash
+export STRATA_ENCRYPTION_KEY=$(openssl rand -base64 32)
+strata run \
+  --data-dir /var/lib/strata \
+  --s3-bucket my-bucket      \
+  --encryption-key-env STRATA_ENCRYPTION_KEY
+```
+
+The key file may contain the key as:
+- **Raw bytes** — 32 bytes
+- **Hex** — 64 lowercase hex characters
+- **Base64** — 44 standard base64 characters (`=`-padded)
+
+### Embedded library
+
+```go
+key := make([]byte, 32)
+if _, err := rand.Read(key); err != nil { ... }
+kp, err := object.NewStaticKeyProvider(key)
+if err != nil { ... }
+
+node, err := strata.Open(strata.Config{
+    DataDir:     "/var/lib/strata",
+    ObjectStore: myS3Store,
+    Encryption: &strata.EncryptionConfig{
+        KeyProvider: kp,
+    },
+})
+```
+
+### Multi-node clusters
+
+All nodes in a cluster **must use the same key**. The key is not stored or transmitted by Strata — each node loads it independently from its key file or environment.
+
+### Limitations (V1)
+
+- **Local disk not encrypted.** Pebble files in `--data-dir` are stored in plaintext. Use OS-level disk encryption (dm-crypt, LUKS, FileVault) for local-at-rest protection.
+- **No key rotation.** Rotating a key requires stopping all nodes and re-encrypting every object in the bucket. A `strata rekey` utility is planned.
+- **Branch nodes.** The branch node and its source must use the same encryption key in V1.
+- **Lockout state.** Rate-limiting lockout state is in-memory and is not affected by encryption.
+
+---
+
 ## Observability
 
 ```bash

--- a/node.go
+++ b/node.go
@@ -160,6 +160,16 @@ func (n *Node) storeRole(r nodeRole) { n.role.Store(int32(r)) }
 func Open(cfg Config) (*Node, error) {
 	cfg.setDefaults()
 
+	// Wrap object stores with transparent AES-256-GCM encryption when configured.
+	if cfg.Encryption != nil {
+		if cfg.ObjectStore != nil {
+			cfg.ObjectStore = object.NewEncryptedStore(cfg.ObjectStore, cfg.Encryption.KeyProvider)
+		}
+		if cfg.AncestorStore != nil {
+			cfg.AncestorStore = object.NewEncryptedStore(cfg.AncestorStore, cfg.Encryption.KeyProvider)
+		}
+	}
+
 	pebbleDir := filepath.Join(cfg.DataDir, "db")
 	walDir := filepath.Join(cfg.DataDir, "wal")
 

--- a/pkg/object/cipher.go
+++ b/pkg/object/cipher.go
@@ -1,0 +1,328 @@
+package object
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+const (
+	encVersion   = byte(0x01)
+	encHeaderLen = 14   // 1 version + 1 keyID + 12 nonce
+	encChunkSize = 64 * 1024
+	encTagSize   = 16 // AES-GCM authentication tag
+)
+
+// KeyProvider supplies the AES-256 key used to encrypt and decrypt objects.
+//
+// V1 ships [StaticKeyProvider]. Future implementations may fetch from AWS KMS,
+// GCP KMS, or HashiCorp Vault — the Key call accepts a context for that reason.
+type KeyProvider interface {
+	// Key returns the 32-byte AES-256 encryption key.
+	Key(ctx context.Context) ([32]byte, error)
+
+	// KeyID returns a 0–255 identifier stored in each encrypted object header.
+	// It is reserved for future key-rotation support; V1 implementations always
+	// return 0.
+	KeyID() uint8
+}
+
+// StaticKeyProvider is a [KeyProvider] backed by a fixed 32-byte AES-256 key.
+// It is safe for concurrent use.
+type StaticKeyProvider struct {
+	key [32]byte
+}
+
+// NewStaticKeyProvider returns a [KeyProvider] that always returns the given key.
+// key must be exactly 32 bytes.
+func NewStaticKeyProvider(key []byte) (*StaticKeyProvider, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("object: AES-256 key must be 32 bytes, got %d", len(key))
+	}
+	p := &StaticKeyProvider{}
+	copy(p.key[:], key)
+	return p, nil
+}
+
+func (p *StaticKeyProvider) Key(_ context.Context) ([32]byte, error) { return p.key, nil }
+func (p *StaticKeyProvider) KeyID() uint8                            { return 0 }
+
+// EncryptedStore wraps a [Store] and transparently encrypts all object data
+// with AES-256-GCM using chunked streaming (64 KiB chunks). Delete and List
+// pass through unchanged; keys are always stored in plaintext.
+//
+// If the inner store also implements [ConditionalStore] or [VersionedStore],
+// EncryptedStore propagates those interfaces, encrypting/decrypting the object
+// body while delegating the conditional logic to the inner store.
+type EncryptedStore struct {
+	inner Store
+	kp    KeyProvider
+}
+
+// NewEncryptedStore returns a [Store] that encrypts all Put/Get data using kp.
+func NewEncryptedStore(inner Store, kp KeyProvider) *EncryptedStore {
+	return &EncryptedStore{inner: inner, kp: kp}
+}
+
+// Inner returns the wrapped store.
+func (e *EncryptedStore) Inner() Store { return e.inner }
+
+func (e *EncryptedStore) Put(ctx context.Context, key string, r io.Reader) error {
+	k, err := e.kp.Key(ctx)
+	if err != nil {
+		return fmt.Errorf("object: encrypt key: %w", err)
+	}
+	pr, pw := io.Pipe()
+	go func() { pw.CloseWithError(encryptStream(pw, r, k, e.kp.KeyID())) }()
+	return e.inner.Put(ctx, key, pr)
+}
+
+func (e *EncryptedStore) Get(ctx context.Context, key string) (io.ReadCloser, error) {
+	rc, err := e.inner.Get(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	k, err := e.kp.Key(ctx)
+	if err != nil {
+		rc.Close()
+		return nil, fmt.Errorf("object: decrypt key: %w", err)
+	}
+	return newDecryptReader(rc, k)
+}
+
+func (e *EncryptedStore) Delete(ctx context.Context, key string) error {
+	return e.inner.Delete(ctx, key)
+}
+
+func (e *EncryptedStore) List(ctx context.Context, prefix string) ([]string, error) {
+	return e.inner.List(ctx, prefix)
+}
+
+// GetETag implements [ConditionalStore]. The ETag is computed by the inner
+// store over the ciphertext — it is opaque for CAS purposes and unaffected by
+// encryption. The returned body is transparently decrypted.
+func (e *EncryptedStore) GetETag(ctx context.Context, key string) (*GetWithETag, error) {
+	cs, ok := e.inner.(ConditionalStore)
+	if !ok {
+		return nil, fmt.Errorf("object: inner store does not implement ConditionalStore")
+	}
+	r, err := cs.GetETag(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	k, err := e.kp.Key(ctx)
+	if err != nil {
+		r.Body.Close()
+		return nil, fmt.Errorf("object: decrypt key: %w", err)
+	}
+	dec, err := newDecryptReader(r.Body, k)
+	if err != nil {
+		return nil, err
+	}
+	return &GetWithETag{Body: dec, ETag: r.ETag}, nil
+}
+
+// PutIfAbsent implements [ConditionalStore].
+func (e *EncryptedStore) PutIfAbsent(ctx context.Context, key string, r io.Reader) error {
+	cs, ok := e.inner.(ConditionalStore)
+	if !ok {
+		return fmt.Errorf("object: inner store does not implement ConditionalStore")
+	}
+	k, err := e.kp.Key(ctx)
+	if err != nil {
+		return fmt.Errorf("object: encrypt key: %w", err)
+	}
+	pr, pw := io.Pipe()
+	go func() { pw.CloseWithError(encryptStream(pw, r, k, e.kp.KeyID())) }()
+	return cs.PutIfAbsent(ctx, key, pr)
+}
+
+// PutIfMatch implements [ConditionalStore].
+func (e *EncryptedStore) PutIfMatch(ctx context.Context, key string, r io.Reader, matchETag string) error {
+	cs, ok := e.inner.(ConditionalStore)
+	if !ok {
+		return fmt.Errorf("object: inner store does not implement ConditionalStore")
+	}
+	k, err := e.kp.Key(ctx)
+	if err != nil {
+		return fmt.Errorf("object: encrypt key: %w", err)
+	}
+	pr, pw := io.Pipe()
+	go func() { pw.CloseWithError(encryptStream(pw, r, k, e.kp.KeyID())) }()
+	return cs.PutIfMatch(ctx, key, pr, matchETag)
+}
+
+// GetVersioned implements [VersionedStore].
+func (e *EncryptedStore) GetVersioned(ctx context.Context, key, versionID string) (io.ReadCloser, error) {
+	vs, ok := e.inner.(VersionedStore)
+	if !ok {
+		return nil, fmt.Errorf("object: inner store does not implement VersionedStore")
+	}
+	rc, err := vs.GetVersioned(ctx, key, versionID)
+	if err != nil {
+		return nil, err
+	}
+	k, err := e.kp.Key(ctx)
+	if err != nil {
+		rc.Close()
+		return nil, fmt.Errorf("object: decrypt key: %w", err)
+	}
+	return newDecryptReader(rc, k)
+}
+
+// ── Streaming encryption ──────────────────────────────────────────────────────
+
+// encryptStream writes the AES-256-GCM encrypted form of r to w.
+//
+// Wire format:
+//
+//	[1: version=0x01][1: keyID][12: fileNonce]
+//	repeated: [4: chunkPlainLen uint32 BE][chunkPlainLen+16: ciphertext+GCM tag]
+//	end:      [4: 0x00000000]
+func encryptStream(w io.Writer, r io.Reader, key [32]byte, keyID uint8) error {
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return err
+	}
+
+	var fileNonce [12]byte
+	if _, err := rand.Read(fileNonce[:]); err != nil {
+		return fmt.Errorf("object: generate nonce: %w", err)
+	}
+
+	// Header: version, keyID, 12-byte file nonce.
+	var hdr [encHeaderLen]byte
+	hdr[0] = encVersion
+	hdr[1] = keyID
+	copy(hdr[2:], fileNonce[:])
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+
+	plain := make([]byte, encChunkSize)
+	var sealed []byte // reused ciphertext buffer
+	var idx uint64
+
+	for {
+		n, readErr := io.ReadFull(r, plain)
+		if n > 0 {
+			cn := chunkNonce(fileNonce, idx)
+			idx++
+			sealed = gcm.Seal(sealed[:0], cn[:], plain[:n], nil)
+
+			var lbuf [4]byte
+			binary.BigEndian.PutUint32(lbuf[:], uint32(n))
+			if _, err := w.Write(lbuf[:]); err != nil {
+				return err
+			}
+			if _, err := w.Write(sealed); err != nil {
+				return err
+			}
+		}
+		if readErr == io.ErrUnexpectedEOF || readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
+
+	// End-of-stream marker.
+	_, err = w.Write([]byte{0, 0, 0, 0})
+	return err
+}
+
+// chunkNonce derives a per-chunk nonce. The first 4 bytes are a random salt
+// from the file nonce; the last 8 bytes are the file-nonce counter XOR'd with
+// the chunk index, keeping each chunk's nonce unique within the object.
+func chunkNonce(base [12]byte, i uint64) [12]byte {
+	var n [12]byte
+	copy(n[:4], base[:4])
+	binary.BigEndian.PutUint64(n[4:], binary.BigEndian.Uint64(base[4:])^i)
+	return n
+}
+
+// ── Streaming decryption ──────────────────────────────────────────────────────
+
+type decryptReader struct {
+	inner    io.Closer
+	r        io.Reader
+	gcm      cipher.AEAD
+	baseNonce [12]byte
+	chunkIdx uint64
+	buf      []byte // current decrypted plaintext chunk
+	pos      int    // read offset in buf
+}
+
+func newDecryptReader(rc io.ReadCloser, key [32]byte) (*decryptReader, error) {
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		rc.Close()
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		rc.Close()
+		return nil, err
+	}
+	dr := &decryptReader{inner: rc, r: rc, gcm: gcm}
+
+	var hdr [encHeaderLen]byte
+	if _, err := io.ReadFull(rc, hdr[:]); err != nil {
+		rc.Close()
+		return nil, fmt.Errorf("object: read encrypted header: %w", err)
+	}
+	if hdr[0] != encVersion {
+		rc.Close()
+		return nil, fmt.Errorf("object: unsupported encryption version %d", hdr[0])
+	}
+	// hdr[1] is keyID — reserved for future rotation, ignored in V1.
+	copy(dr.baseNonce[:], hdr[2:encHeaderLen])
+	return dr, nil
+}
+
+func (d *decryptReader) Read(p []byte) (int, error) {
+	for {
+		if d.pos < len(d.buf) {
+			n := copy(p, d.buf[d.pos:])
+			d.pos += n
+			return n, nil
+		}
+
+		var lbuf [4]byte
+		if _, err := io.ReadFull(d.r, lbuf[:]); err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				return 0, io.ErrUnexpectedEOF
+			}
+			return 0, fmt.Errorf("object: read chunk length: %w", err)
+		}
+		plainLen := binary.BigEndian.Uint32(lbuf[:])
+		if plainLen == 0 {
+			return 0, io.EOF
+		}
+
+		cipherBuf := make([]byte, int(plainLen)+encTagSize)
+		if _, err := io.ReadFull(d.r, cipherBuf); err != nil {
+			return 0, fmt.Errorf("object: read chunk ciphertext: %w", err)
+		}
+
+		cn := chunkNonce(d.baseNonce, d.chunkIdx)
+		d.chunkIdx++
+		plain, err := d.gcm.Open(cipherBuf[:0], cn[:], cipherBuf, nil)
+		if err != nil {
+			return 0, fmt.Errorf("object: decrypt chunk %d: authentication failed", d.chunkIdx-1)
+		}
+		d.buf = plain
+		d.pos = 0
+	}
+}
+
+func (d *decryptReader) Close() error { return d.inner.Close() }

--- a/pkg/object/cipher_test.go
+++ b/pkg/object/cipher_test.go
@@ -1,0 +1,334 @@
+package object
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// ── StaticKeyProvider ─────────────────────────────────────────────────────────
+
+func TestNewStaticKeyProvider_BadLength(t *testing.T) {
+	_, err := NewStaticKeyProvider(make([]byte, 16))
+	if err == nil {
+		t.Fatal("expected error for 16-byte key")
+	}
+}
+
+func TestNewStaticKeyProvider_Good(t *testing.T) {
+	key := make([]byte, 32)
+	key[0] = 0xAB
+	kp, err := NewStaticKeyProvider(key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, err := kp.Key(context.Background())
+	if err != nil {
+		t.Fatalf("Key() error: %v", err)
+	}
+	if got[0] != 0xAB {
+		t.Fatalf("key mismatch: got[0]=%x want 0xAB", got[0])
+	}
+	if kp.KeyID() != 0 {
+		t.Fatalf("KeyID should be 0, got %d", kp.KeyID())
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func newTestProvider(t *testing.T) *StaticKeyProvider {
+	t.Helper()
+	kp, err := NewStaticKeyProvider(make([]byte, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return kp
+}
+
+func newEncryptedMem(t *testing.T) (*EncryptedStore, *Mem) {
+	t.Helper()
+	mem := NewMem()
+	es := NewEncryptedStore(mem, newTestProvider(t))
+	return es, mem
+}
+
+// ── Put / Get roundtrip ───────────────────────────────────────────────────────
+
+func TestEncryptedStore_Roundtrip(t *testing.T) {
+	es, _ := newEncryptedMem(t)
+	ctx := context.Background()
+	plain := []byte("hello, encrypted world!")
+
+	if err := es.Put(ctx, "k", bytes.NewReader(plain)); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	rc, err := es.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer rc.Close()
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, plain) {
+		t.Fatalf("roundtrip mismatch: got %q want %q", got, plain)
+	}
+}
+
+func TestEncryptedStore_CiphertextDiffersFromPlaintext(t *testing.T) {
+	es, mem := newEncryptedMem(t)
+	ctx := context.Background()
+	plain := []byte("secret data that must not appear in S3")
+
+	if err := es.Put(ctx, "key", bytes.NewReader(plain)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read raw bytes from inner store (the ciphertext).
+	rc, _ := mem.Get(ctx, "key")
+	raw, _ := io.ReadAll(rc)
+	rc.Close()
+
+	if bytes.Contains(raw, plain) {
+		t.Fatal("plaintext found verbatim in stored ciphertext")
+	}
+}
+
+func TestEncryptedStore_EmptyValue(t *testing.T) {
+	es, _ := newEncryptedMem(t)
+	ctx := context.Background()
+
+	if err := es.Put(ctx, "empty", bytes.NewReader(nil)); err != nil {
+		t.Fatalf("Put empty: %v", err)
+	}
+	rc, err := es.Get(ctx, "empty")
+	if err != nil {
+		t.Fatalf("Get empty: %v", err)
+	}
+	defer rc.Close()
+	got, _ := io.ReadAll(rc)
+	if len(got) != 0 {
+		t.Fatalf("expected empty, got %d bytes", len(got))
+	}
+}
+
+func TestEncryptedStore_WrongKey(t *testing.T) {
+	mem := NewMem()
+	ctx := context.Background()
+
+	kp1, _ := NewStaticKeyProvider(bytes.Repeat([]byte{0x01}, 32))
+	kp2, _ := NewStaticKeyProvider(bytes.Repeat([]byte{0x02}, 32))
+
+	if err := NewEncryptedStore(mem, kp1).Put(ctx, "k", strings.NewReader("data")); err != nil {
+		t.Fatal(err)
+	}
+	rc, err := NewEncryptedStore(mem, kp2).Get(ctx, "k")
+	if err != nil {
+		// Some decryption errors surface in newDecryptReader (header), others in Read.
+		return
+	}
+	defer rc.Close()
+	_, err = io.ReadAll(rc)
+	if err == nil {
+		t.Fatal("expected error when decrypting with wrong key")
+	}
+}
+
+func TestEncryptedStore_TruncatedCiphertext(t *testing.T) {
+	es, mem := newEncryptedMem(t)
+	ctx := context.Background()
+
+	if err := es.Put(ctx, "k", strings.NewReader("some data")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Truncate the stored ciphertext.
+	rc, _ := mem.Get(ctx, "k")
+	raw, _ := io.ReadAll(rc)
+	rc.Close()
+	_ = mem.Put(ctx, "k", bytes.NewReader(raw[:len(raw)/2]))
+
+	r, err := es.Get(ctx, "k")
+	if err != nil {
+		return // header read failure is acceptable
+	}
+	defer r.Close()
+	_, err = io.ReadAll(r)
+	if err == nil {
+		t.Fatal("expected error reading truncated ciphertext")
+	}
+}
+
+// ── Chunk boundary tests ──────────────────────────────────────────────────────
+
+func TestEncryptedStore_ExactlyOneChunk(t *testing.T) {
+	testRoundtrip(t, encChunkSize)
+}
+
+func TestEncryptedStore_OneChunkPlusOne(t *testing.T) {
+	testRoundtrip(t, encChunkSize+1)
+}
+
+func TestEncryptedStore_MultipleChunks(t *testing.T) {
+	testRoundtrip(t, 5*encChunkSize+7)
+}
+
+func testRoundtrip(t *testing.T, size int) {
+	t.Helper()
+	es, _ := newEncryptedMem(t)
+	ctx := context.Background()
+
+	plain := make([]byte, size)
+	for i := range plain {
+		plain[i] = byte(i)
+	}
+
+	if err := es.Put(ctx, "k", bytes.NewReader(plain)); err != nil {
+		t.Fatalf("Put(%d bytes): %v", size, err)
+	}
+	rc, err := es.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer rc.Close()
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, plain) {
+		t.Fatalf("roundtrip mismatch for %d bytes", size)
+	}
+}
+
+// ── Different random nonce per object ─────────────────────────────────────────
+
+func TestEncryptedStore_TwoIdenticalPlaintextsProduceDifferentCiphertexts(t *testing.T) {
+	es, mem := newEncryptedMem(t)
+	ctx := context.Background()
+	plain := []byte("same content")
+
+	_ = es.Put(ctx, "a", bytes.NewReader(plain))
+	_ = es.Put(ctx, "b", bytes.NewReader(plain))
+
+	rca, _ := mem.Get(ctx, "a")
+	rawA, _ := io.ReadAll(rca)
+	rca.Close()
+
+	rcb, _ := mem.Get(ctx, "b")
+	rawB, _ := io.ReadAll(rcb)
+	rcb.Close()
+
+	if bytes.Equal(rawA, rawB) {
+		t.Fatal("two puts of the same plaintext produced identical ciphertext (nonce reuse?)")
+	}
+}
+
+// ── Delete / List pass-through ────────────────────────────────────────────────
+
+func TestEncryptedStore_DeleteList(t *testing.T) {
+	es, _ := newEncryptedMem(t)
+	ctx := context.Background()
+
+	_ = es.Put(ctx, "a", strings.NewReader("x"))
+	_ = es.Put(ctx, "b", strings.NewReader("y"))
+
+	keys, err := es.List(ctx, "")
+	if err != nil || len(keys) != 2 {
+		t.Fatalf("List: got %v err=%v", keys, err)
+	}
+
+	if err := es.Delete(ctx, "a"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	keys, _ = es.List(ctx, "")
+	if len(keys) != 1 || keys[0] != "b" {
+		t.Fatalf("after Delete, expected [b], got %v", keys)
+	}
+}
+
+// ── ConditionalStore delegation ───────────────────────────────────────────────
+
+func TestEncryptedStore_ConditionalStore(t *testing.T) {
+	es, _ := newEncryptedMem(t)
+	ctx := context.Background()
+
+	// PutIfAbsent should succeed on a new key.
+	if err := es.PutIfAbsent(ctx, "k", strings.NewReader("v1")); err != nil {
+		t.Fatalf("PutIfAbsent: %v", err)
+	}
+	// PutIfAbsent should fail because key now exists.
+	err := es.PutIfAbsent(ctx, "k", strings.NewReader("v2"))
+	if !errors.Is(err, ErrPreconditionFailed) {
+		t.Fatalf("expected ErrPreconditionFailed, got %v", err)
+	}
+
+	// GetETag returns decrypted body and an ETag.
+	r, err := es.GetETag(ctx, "k")
+	if err != nil {
+		t.Fatalf("GetETag: %v", err)
+	}
+	body, _ := io.ReadAll(r.Body)
+	r.Body.Close()
+	if string(body) != "v1" {
+		t.Fatalf("GetETag body: got %q want v1", body)
+	}
+	if r.ETag == "" {
+		t.Fatal("GetETag returned empty ETag")
+	}
+
+	// PutIfMatch with correct ETag should succeed.
+	if err := es.PutIfMatch(ctx, "k", strings.NewReader("v3"), r.ETag); err != nil {
+		t.Fatalf("PutIfMatch with correct ETag: %v", err)
+	}
+
+	// PutIfMatch with stale ETag should fail.
+	err = es.PutIfMatch(ctx, "k", strings.NewReader("v4"), r.ETag)
+	if !errors.Is(err, ErrPreconditionFailed) {
+		t.Fatalf("PutIfMatch stale: expected ErrPreconditionFailed, got %v", err)
+	}
+
+	// Final value should be "v3".
+	rc, _ := es.Get(ctx, "k")
+	final, _ := io.ReadAll(rc)
+	rc.Close()
+	if string(final) != "v3" {
+		t.Fatalf("final value: got %q want v3", final)
+	}
+}
+
+func TestEncryptedStore_ConditionalStore_NotSupported(t *testing.T) {
+	// A Store that does NOT implement ConditionalStore.
+	es := NewEncryptedStore(&noopStore{}, newTestProvider(t))
+	ctx := context.Background()
+
+	if _, err := es.GetETag(ctx, "k"); err == nil {
+		t.Fatal("expected error when inner has no ConditionalStore")
+	}
+	if err := es.PutIfAbsent(ctx, "k", strings.NewReader("v")); err == nil {
+		t.Fatal("expected error when inner has no ConditionalStore")
+	}
+	if err := es.PutIfMatch(ctx, "k", strings.NewReader("v"), "etag"); err == nil {
+		t.Fatal("expected error when inner has no ConditionalStore")
+	}
+}
+
+func TestEncryptedStore_VersionedStore_NotSupported(t *testing.T) {
+	es := NewEncryptedStore(&noopStore{}, newTestProvider(t))
+	ctx := context.Background()
+
+	if _, err := es.GetVersioned(ctx, "k", "v1"); err == nil {
+		t.Fatal("expected error when inner has no VersionedStore")
+	}
+}
+
+// noopStore is a minimal Store that does not implement any optional interfaces.
+type noopStore struct{}
+
+func (s *noopStore) Put(_ context.Context, _ string, _ io.Reader) error      { return nil }
+func (s *noopStore) Get(_ context.Context, _ string) (io.ReadCloser, error)  { return nil, ErrNotFound }
+func (s *noopStore) Delete(_ context.Context, _ string) error                { return nil }
+func (s *noopStore) List(_ context.Context, _ string) ([]string, error)      { return nil, nil }

--- a/website/src/content/docs/architecture.md
+++ b/website/src/content/docs/architecture.md
@@ -216,6 +216,30 @@ Entries are stored at `branches/<id>` in the source store as JSON:
 
 ---
 
+## Encryption at rest
+
+When `Config.Encryption` is set, Strata wraps the `object.Store` with an `EncryptedStore` at startup. Every object written to or read from the store (WAL segments, SST files, checkpoint indices, manifests, leader-lock) is transparently encrypted and decrypted — no changes are required in the WAL, SST uploader, or checkpoint code.
+
+**Algorithm:** AES-256-GCM (AEAD — provides both confidentiality and integrity).
+
+**Per-object wire format (chunked streaming, 64 KiB chunks):**
+
+```
+[1: version=0x01][1: keyID][12: fileNonce]
+repeated: [4: chunkPlainLen uint32 BE][chunkPlainLen+16: ciphertext+GCM tag]
+end:       [4: 0x00000000]
+```
+
+Each object gets a fresh 12-byte random `fileNonce`. Per-chunk nonces are derived by XOR-ing the last 8 bytes of the file nonce with the chunk index, ensuring every (file, chunk) pair has a unique nonce. Overhead is 30 bytes per object plus 16 bytes (GCM tag) per 64 KiB chunk.
+
+**Content-addressed SST deduplication is preserved.** SST keys are `sst/{hash16-of-plaintext}/{name}` — the hash is computed from the *plaintext* before upload. The encrypted ciphertext stored at that key differs per upload (different random nonce), but the key still identifies the content, so duplicate-detection ("does this key already exist?") works correctly.
+
+**Optional interface propagation.** `EncryptedStore` delegates `ConditionalStore` (leader election CAS) and `VersionedStore` (point-in-time restore) to the inner store, encrypting/decrypting only the object body while leaving ETag and version-ID semantics unchanged.
+
+**Scope.** S3 objects only. Local Pebble files are not encrypted in V1. A future `EncryptedFS` (`vfs.FS` wrapper for Pebble) is planned.
+
+---
+
 ## Concurrency model
 
 - **Revision assignment** is serialised under `node.mu`. This keeps the revision counter monotonic.

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -30,6 +30,13 @@ description: All strata.Config fields and CLI flags for the Strata standalone bi
 | `PeerClientTLS` | `credentials.TransportCredentials` | `nil` | mTLS credentials for the peer gRPC client (follower side). |
 | `MetricsAddr` | `string` | `""` | HTTP address for `/metrics`, `/healthz`, `/readyz`. Empty = disabled. |
 | `ReadConsistency` | `ReadConsistency` | `"linearizable"` | Consistency guarantee for reads served by the etcd adapter. `"linearizable"` (default): each read syncs to the leader's current revision before returning, ensuring no stale reads. `"serializable"`: reads are served from local Pebble state without a round-trip to the leader; lower latency but may return slightly stale data on followers. |
+| `Encryption` | `*EncryptionConfig` | `nil` | When non-nil, enables AES-256-GCM encryption for all data written to and read from the object store (WAL segments, SST files, checkpoints, manifests). Local Pebble files on disk are not encrypted. See [Encryption at rest](operations.md#encryption-at-rest). |
+
+### `EncryptionConfig`
+
+| Field | Type | Description |
+|---|---|---|
+| `KeyProvider` | `object.KeyProvider` | Supplies the 32-byte AES-256 key. Use `object.NewStaticKeyProvider(key)` for a fixed key loaded at startup. The interface is designed for future KMS backends. |
 
 ### Using a custom S3-compatible store
 
@@ -97,6 +104,8 @@ strata run [flags]
 | `--auth-enabled` | `false` | Enable etcd-compatible authentication and RBAC |
 | `--token-ttl` | `300` | Bearer token lifetime in seconds |
 | `--metrics-addr` | — | HTTP address for metrics and health endpoints |
+| `--encryption-key-file` | — | Path to file containing a 32-byte AES-256 key (raw, hex-encoded, or base64-encoded). Enables encryption at rest for all S3 objects. |
+| `--encryption-key-env` | — | Environment variable holding a base64-encoded 32-byte AES-256 key. Alternative to `--encryption-key-file`. |
 | `--branch-source-bucket` | — | S3 bucket of the source database (branch nodes only) |
 | `--branch-source-prefix` | — | S3 prefix of the source database (branch nodes only) |
 | `--branch-source-endpoint` | — | S3 endpoint of the source database (branch nodes only) |

--- a/website/src/content/docs/operations.md
+++ b/website/src/content/docs/operations.md
@@ -329,6 +329,74 @@ etcdctl --user svc-account:pass get /secrets/key         # PermissionDenied
 
 ---
 
+## Encryption at rest
+
+Strata can encrypt all data written to the object store (WAL segments, SST files, checkpoints, and manifests) using AES-256-GCM. Each object is encrypted with a unique random nonce; the authentication tag provides integrity verification on every read. Local Pebble files on disk are not encrypted.
+
+### Enabling encryption
+
+Generate a 32-byte key and store it securely:
+
+```bash
+# Generate a random key and save it (base64-encoded)
+openssl rand -base64 32 > /etc/strata/encryption.key
+chmod 600 /etc/strata/encryption.key
+```
+
+Pass the key file to the node:
+
+```bash
+strata run \
+  --data-dir /var/lib/strata \
+  --s3-bucket my-bucket      \
+  --encryption-key-file /etc/strata/encryption.key
+```
+
+Alternatively, supply the key via an environment variable:
+
+```bash
+export STRATA_ENCRYPTION_KEY=$(openssl rand -base64 32)
+strata run \
+  --data-dir /var/lib/strata \
+  --s3-bucket my-bucket      \
+  --encryption-key-env STRATA_ENCRYPTION_KEY
+```
+
+The key file may contain the key as:
+- **Raw bytes** — 32 bytes
+- **Hex** — 64 lowercase hex characters
+- **Base64** — 44 standard base64 characters (`=`-padded)
+
+### Embedded library
+
+```go
+key := make([]byte, 32)
+if _, err := rand.Read(key); err != nil { ... }
+kp, err := object.NewStaticKeyProvider(key)
+if err != nil { ... }
+
+node, err := strata.Open(strata.Config{
+    DataDir:     "/var/lib/strata",
+    ObjectStore: myS3Store,
+    Encryption: &strata.EncryptionConfig{
+        KeyProvider: kp,
+    },
+})
+```
+
+### Multi-node clusters
+
+All nodes in a cluster **must use the same key**. The key is not stored or transmitted by Strata — each node loads it independently from its key file or environment.
+
+### Limitations (V1)
+
+- **Local disk not encrypted.** Pebble files in `--data-dir` are stored in plaintext. Use OS-level disk encryption (dm-crypt, LUKS, FileVault) for local-at-rest protection.
+- **No key rotation.** Rotating a key requires stopping all nodes and re-encrypting every object in the bucket. A `strata rekey` utility is planned.
+- **Branch nodes.** The branch node and its source must use the same encryption key in V1.
+- **Lockout state.** Rate-limiting lockout state is in-memory and is not affected by encryption.
+
+---
+
 ## Observability
 
 ```bash


### PR DESCRIPTION
All data written to the object store (WAL segments, SST files, checkpoint indices, manifests) is transparently encrypted using AES-256-GCM.

Implementation:
- pkg/object/cipher.go: KeyProvider interface, StaticKeyProvider, chunked streaming AEAD (64 KiB chunks), EncryptedStore wrapper. Delegates ConditionalStore and VersionedStore to the inner store so leader election CAS and point-in-time restore work unchanged.
- config.go: EncryptionConfig{KeyProvider} field on Config.
- node.go: wrap ObjectStore and AncestorStore at Open() time when Encryption is set — single insertion point, zero changes to WAL/SST/ checkpoint code.
- cmd/strata/main.go: --encryption-key-file and --encryption-key-env flags; loadEncryptionKey parses raw/hex/base64 32-byte keys.

Wire format: [1:version][1:keyID][12:fileNonce] + chunks of [4:len][N+16:ciphertext+GCM tag], terminated by [4:0]. Per-chunk nonces are derived by XOR-ing the file nonce counter with the chunk index. Content-addressed SST deduplication is preserved (S3 key = hash of plaintext; ciphertext differs per upload but key is the same).

V1 limitations (documented):
- Local Pebble files not encrypted (planned: vfs.FS wrapper)
- No key rotation (planned: strata rekey utility)
- Branch source and branch node must share the same key