### PR TITLE
test: add follower-kill and network-partition tests; expand failure docs

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -434,7 +434,54 @@ Steps 4–5 ensure that no committed write is lost even if the node is killed be
 
 ### S3 unavailability
 
-In cluster mode, S3 uploads are fully async — WAL segments and checkpoints are uploaded in the background without blocking writes. In single-node mode, each WAL segment is uploaded to S3 synchronously before the write is acknowledged. In both modes, on restart local WAL segments are replayed first, so no data written to the local WAL is lost even if it was never uploaded to S3.
+**Cluster mode**
+
+In cluster mode, S3 uploads are fully async — WAL segments and checkpoints are uploaded in the background without blocking writes. If S3 becomes unavailable:
+
+- **Writes continue.** Durability is backed by the peer WAL + quorum ACK across nodes, not by S3.
+- **WAL uploads queue.** Failed uploads are retried; a backlog of unsealed segments accumulates in `<data-dir>/wal/`.
+- **Leader election is unaffected** as long as the existing lock record is still readable from S3. If the lock expires or cannot be read, election is blocked until S3 is reachable again.
+- **No committed write is lost.** On restart, local WAL segments are replayed before any S3 reads (step 4 of the recovery procedure). Data that was fsynced to local disk is safe regardless of S3 state.
+
+**Single-node mode**
+
+In single-node mode, each WAL segment is uploaded to S3 synchronously before the write is acknowledged. If S3 becomes unavailable:
+
+- **Writes fail** once the in-progress WAL segment fills and a rotation is attempted. The node fences itself to prevent unacknowledged data from accumulating silently.
+- **Already-acknowledged writes are safe.** All segments uploaded before the outage are on S3; the current open segment is on local disk.
+- **To recover:** repair S3 access and restart the node. On startup it replays all local WAL segments (including any partial segment left on disk), then resumes normal operation.
+
+**After any S3 outage — what is safe**
+
+On startup, Strata replays local WAL segments (step 4) before reading from S3, so no write that was fsynced to local disk is lost even if the segment was never uploaded. In cluster mode with multiple survivors, any write that completed quorum ACK across nodes is never lost even if all S3 state is gone.
+
+---
+
+### Network partitions (cluster mode)
+
+Strata uses S3 as the split-brain arbiter. The leader continuously refreshes a `LastSeenNano` timestamp in the S3 leader lock every `FollowerRetryInterval` (2 s) while followers are disconnected. A follower only promotes itself if it cannot reach the leader **and** the lock is older than `LeaderLivenessTTL` (6 s).
+
+**Follower partitioned from leader, leader can still reach S3:**
+
+1. Follower loses the peer stream; leader detects the disconnect.
+2. Leader immediately touches `LastSeenNano` in the lock, then continues refreshing every 2 s.
+3. Follower exhausts `--follower-max-retries` reconnect attempts (~4 s at the default of 2 × 2 s).
+4. Follower reads the S3 lock — `LastSeenNano` is ≤ 2 s old → backs off, **does not promote**.
+5. Follower keeps retrying the peer connection; leader keeps writing.
+6. When the partition heals the follower reconnects and resyncs. **No split-brain. No data loss.**
+
+**Leader partitioned from S3 (and from followers):**
+
+1. Leader can no longer touch `LastSeenNano`.
+2. After `LeaderLivenessTTL` (6 s) the lock goes stale.
+3. A follower that has been retrying attempts a conditional PUT (`If-Match: <etag>`) on the lock — only one candidate wins this atomic race.
+4. New leader begins streaming WAL entries.
+5. Former leader detects the superseded lock on its next fenced check and steps down.
+6. Any write that completed quorum ACK before the partition exists on at least two nodes' WALs and is **never lost**.
+
+**Writes during a follower partition:**
+
+While followers are disconnected, the leader's `WaitForFollowers` returns immediately (0 connected followers → 0 ACKs required). Writes proceed but are acknowledged only by the leader node. WAL segments continue to be uploaded to S3 asynchronously. If the leader fails while the partition persists and before the segments reach S3, those post-partition writes may be lost. For the highest write durability during a known partition, avoid acknowledging client writes until the partition heals, or use a 3-node cluster so quorum (2 of 3) can still be reached with one node partitioned.
 
 ---
 

--- a/failure_test.go
+++ b/failure_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1030,4 +1031,302 @@ func TestLocalWALUploadedOnLeaderElection(t *testing.T) {
 			t.Errorf("phase-3 Get k%d: err=%v kv=%v", i, err, kv)
 		}
 	}
+}
+
+// ── blockableProxy ────────────────────────────────────────────────────────────
+
+// blockableProxy is a TCP proxy that can be paused to simulate a network
+// partition. All connections are forwarded transparently to target; calling
+// block() closes existing connections and refuses new ones until unblock().
+type blockableProxy struct {
+	lis     net.Listener
+	target  string
+	blocked int32 // atomic bool: 1 = drop connections, 0 = forward
+	connsMu sync.Mutex
+	conns   []net.Conn
+}
+
+func newBlockableProxy(t testing.TB, target string) *blockableProxy {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("blockableProxy: listen: %v", err)
+	}
+	p := &blockableProxy{lis: lis, target: target}
+	go p.serve()
+	t.Cleanup(func() { lis.Close() })
+	return p
+}
+
+func (p *blockableProxy) Addr() string { return p.lis.Addr().String() }
+
+// block closes all active connections and causes new ones to be refused
+// immediately until unblock() is called.
+func (p *blockableProxy) block() {
+	atomic.StoreInt32(&p.blocked, 1)
+	p.connsMu.Lock()
+	for _, c := range p.conns {
+		c.Close()
+	}
+	p.conns = p.conns[:0]
+	p.connsMu.Unlock()
+}
+
+func (p *blockableProxy) unblock() { atomic.StoreInt32(&p.blocked, 0) }
+
+func (p *blockableProxy) serve() {
+	for {
+		c, err := p.lis.Accept()
+		if err != nil {
+			return // listener closed (test cleanup)
+		}
+		if atomic.LoadInt32(&p.blocked) == 1 {
+			c.Close()
+			continue
+		}
+		dst, err := net.Dial("tcp", p.target)
+		if err != nil {
+			c.Close()
+			continue
+		}
+		p.connsMu.Lock()
+		p.conns = append(p.conns, c, dst)
+		p.connsMu.Unlock()
+		go func() { io.Copy(dst, c); dst.Close(); c.Close() }()
+		go func() { io.Copy(c, dst); c.Close(); dst.Close() }()
+	}
+}
+
+// ── TestFollowerKilledDuringCommit ────────────────────────────────────────────
+
+// TestFollowerKilledDuringCommit verifies that the leader and remaining
+// follower continue accepting writes after one follower is killed mid-stream,
+// and that the killed follower resyncs correctly when it rejoins with a fresh
+// data directory (bootstrap from S3 checkpoint + WAL replay + live stream).
+func TestFollowerKilledDuringCommit(t *testing.T) {
+	store := object.NewMem()
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	nodes := openCluster(t, 3, store)
+	leader := waitForLeaderNode(t, nodes, 10*time.Second)
+	leaderIdx := -1
+	for i, n := range nodes {
+		if n == leader {
+			leaderIdx = i
+			break
+		}
+	}
+	t.Logf("leader: node-%d", leaderIdx)
+
+	// Phase 1: write initial batch and wait for full replication.
+	const phase1 = 10
+	var lastRev int64
+	for i := 0; i < phase1; i++ {
+		rev, err := leader.Put(ctx, fmt.Sprintf("/kill/%d", i), []byte("before"), 0)
+		if err != nil {
+			t.Fatalf("phase1 Put: %v", err)
+		}
+		lastRev = rev
+	}
+	for i, n := range nodes {
+		if n == leader {
+			continue
+		}
+		if err := n.WaitForRevision(ctx, lastRev); err != nil {
+			t.Fatalf("node-%d WaitForRevision phase1: %v", i, err)
+		}
+	}
+
+	// Kill one follower.
+	var victimIdx int
+	for i, n := range nodes {
+		if n != leader {
+			t.Logf("killing follower node-%d", i)
+			victimIdx = i
+			n.Close()
+			break
+		}
+	}
+
+	// Phase 2: continue writing while only leader + 1 follower remain.
+	// WaitForFollowers with 1 connected follower requires 1 ACK (quorum),
+	// so writes proceed normally.
+	const phase2 = 10
+	for i := phase1; i < phase1+phase2; i++ {
+		rev, err := leader.Put(ctx, fmt.Sprintf("/kill/%d", i), []byte("after"), 0)
+		if err != nil {
+			t.Fatalf("phase2 Put after killing follower node-%d: %v", victimIdx, err)
+		}
+		lastRev = rev
+	}
+	t.Logf("phase2 complete: wrote %d keys with follower node-%d down", phase2, victimIdx)
+
+	// Let checkpoint and WAL segments flush to the object store.
+	time.Sleep(1500 * time.Millisecond)
+
+	// Restart the killed follower with a fresh data dir so it must bootstrap
+	// entirely from S3 (checkpoint restore + WAL replay), then catch up via
+	// the live peer stream from the leader.
+	rejoinPeer := freeAddrImpl(t)
+	rejoined, err := strata.Open(strata.Config{
+		DataDir:            t.TempDir(),
+		ObjectStore:        store,
+		NodeID:             fmt.Sprintf("node-%d", victimIdx),
+		PeerListenAddr:     rejoinPeer,
+		AdvertisePeerAddr:  rejoinPeer,
+		FollowerMaxRetries: 2,
+		PeerBufferSize:     1000,
+		CheckpointInterval: 300 * time.Millisecond,
+		SegmentMaxAge:      200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("rejoin open: %v", err)
+	}
+	t.Cleanup(func() { rejoined.Close() })
+
+	if err := rejoined.WaitForRevision(ctx, lastRev); err != nil {
+		t.Fatalf("rejoined WaitForRevision(%d): %v", lastRev, err)
+	}
+
+	// All keys from both phases must be present on the rejoined node.
+	for i := 0; i < phase1+phase2; i++ {
+		kv, err := rejoined.Get(fmt.Sprintf("/kill/%d", i))
+		if err != nil || kv == nil {
+			t.Errorf("rejoined: /kill/%d missing: err=%v kv=%v", i, err, kv)
+		}
+	}
+	t.Logf("rejoined node has all %d keys", phase1+phase2)
+}
+
+// ── TestNetworkPartitionNoSplitBrain ─────────────────────────────────────────
+
+// TestNetworkPartitionNoSplitBrain verifies two properties of partition handling:
+//
+//  1. No split-brain: a follower partitioned from the leader does NOT promote
+//     itself while the leader is alive. The leader keeps LastSeenNano fresh
+//     in the S3 lock every FollowerRetryInterval (2 s); the follower reads
+//     this and backs off from TakeOver because the lock age < LeaderLivenessTTL
+//     (6 s).
+//
+//  2. Convergence on heal: when the partition is removed the follower reconnects
+//     through the proxy, resyncs from the leader, and converges on all keys.
+//
+// A blockableProxy sits between the follower and the leader's peer port so the
+// partition can be injected and healed without killing either process.
+func TestNetworkPartitionNoSplitBrain(t *testing.T) {
+	store := object.NewMem()
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	// Allocate the leader's real peer address and wrap it in a blockable proxy.
+	// The leader advertises the proxy address so the follower dials through it.
+	leaderPeerReal := freeAddrImpl(t)
+	proxy := newBlockableProxy(t, leaderPeerReal)
+
+	leaderNode, err := strata.Open(strata.Config{
+		DataDir:            t.TempDir(),
+		ObjectStore:        store,
+		NodeID:             "leader",
+		PeerListenAddr:     leaderPeerReal,
+		AdvertisePeerAddr:  proxy.Addr(), // follower connects through proxy
+		FollowerMaxRetries: 2,
+		PeerBufferSize:     1000,
+		CheckpointInterval: 300 * time.Millisecond,
+		SegmentMaxAge:      200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("open leader: %v", err)
+	}
+	t.Cleanup(func() { leaderNode.Close() })
+
+	// Wait for this node to hold the S3 leader lock before starting the follower,
+	// preventing a race where the follower wins the election instead.
+	deadline := time.Now().Add(10 * time.Second)
+	for !leaderNode.IsLeader() {
+		if time.Now().After(deadline) {
+			t.Fatal("leader node did not acquire lock within timeout")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	followerPeer := freeAddrImpl(t)
+	followerNode, err := strata.Open(strata.Config{
+		DataDir:            t.TempDir(),
+		ObjectStore:        store,
+		NodeID:             "follower",
+		PeerListenAddr:     followerPeer,
+		AdvertisePeerAddr:  followerPeer,
+		FollowerMaxRetries: 2,
+		PeerBufferSize:     1000,
+		CheckpointInterval: 300 * time.Millisecond,
+		SegmentMaxAge:      200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("open follower: %v", err)
+	}
+	t.Cleanup(func() { followerNode.Close() })
+
+	// Phase 1: write and verify replication to confirm the follower is connected.
+	const phase1 = 10
+	var lastRev int64
+	for i := 0; i < phase1; i++ {
+		rev, err := leaderNode.Put(ctx, fmt.Sprintf("/partition/%d", i), []byte("before"), 0)
+		if err != nil {
+			t.Fatalf("phase1 Put: %v", err)
+		}
+		lastRev = rev
+	}
+	if err := followerNode.WaitForRevision(ctx, lastRev); err != nil {
+		t.Fatalf("follower WaitForRevision phase1: %v", err)
+	}
+	t.Logf("phase1 complete: follower at rev=%d", lastRev)
+
+	// Inject partition: follower can no longer reach the leader's peer port.
+	t.Log("blocking proxy — simulating network partition")
+	proxy.block()
+
+	// Wait long enough for the follower to exhaust FollowerMaxRetries (2 × 2 s =
+	// 4 s), attempt TakeOver, see a fresh lock, and back off. We wait 10 s to
+	// cover multiple full retry+takeover cycles, ensuring the behaviour is stable
+	// and not just a transient timing window.
+	time.Sleep(10 * time.Second)
+
+	// ── split-brain check ─────────────────────────────────────────────────────
+	if followerNode.IsLeader() {
+		t.Error("SPLIT-BRAIN: follower promoted itself while real leader is alive")
+	}
+	if !leaderNode.IsLeader() {
+		t.Error("original leader unexpectedly lost leadership during partition")
+	}
+
+	// Phase 2: leader accepts writes while the follower is partitioned.
+	// WaitForFollowers with 0 connected followers returns immediately
+	// (quorum of 0 = 0 ACKs required), so the leader continues.
+	const phase2 = 5
+	for i := phase1; i < phase1+phase2; i++ {
+		rev, err := leaderNode.Put(ctx, fmt.Sprintf("/partition/%d", i), []byte("during-partition"), 0)
+		if err != nil {
+			t.Fatalf("phase2 Put during partition: %v", err)
+		}
+		lastRev = rev
+	}
+	t.Logf("phase2 complete: leader at rev=%d during partition", lastRev)
+
+	// Heal the partition.
+	t.Log("unblocking proxy — healing partition")
+	proxy.unblock()
+
+	// Follower must reconnect through the proxy and resync to the current revision.
+	if err := followerNode.WaitForRevision(ctx, lastRev); err != nil {
+		t.Fatalf("follower WaitForRevision after partition heal: %v", err)
+	}
+
+	// All keys from both phases must be visible on the follower.
+	for i := 0; i < phase1+phase2; i++ {
+		kv, err := followerNode.Get(fmt.Sprintf("/partition/%d", i))
+		if err != nil || kv == nil {
+			t.Errorf("follower: /partition/%d missing after heal: err=%v kv=%v", i, err, kv)
+		}
+	}
+	t.Logf("partition healed: follower converged on all %d keys", phase1+phase2)
 }

--- a/strata-production-checklist.md
+++ b/strata-production-checklist.md
@@ -1,0 +1,141 @@
+# Strata Production Readiness Checklist
+
+## Overview
+This checklist defines the criteria required for Strata to be considered production-ready.
+It is divided into stages and clear pass/fail requirements.
+
+---
+
+## Stage 1 — Internal / Dev Readiness
+
+### Correctness
+- [x] No lost acknowledged writes — WAL + quorum ACK; `TestLeaderCrashBeforeWALFlush`, `TestDeletedKeyDurability`
+- [x] Monotonic revisions guaranteed — `TestRevisionMonotonicity`, `TestConcurrentCompactPutRevisionUniqueness`
+- [x] WAL + checkpoint replay deterministic — `TestWALReplayAfterPartialUpload`, `TestStartupCheckpointCoversLocalWAL`
+- [x] No split-brain commits (fencing works) — conditional PUT (`If-None-Match`/`If-Match`); `TestCommitLoopWALErrorFences`
+
+### Basic Operations
+- [x] Can start cluster (1 node) — `TestE2EOffline`, `TestE2ESingleNodeS3`
+- [x] Can scale 1 → 3 → 1 — `TestScale3To1`, `TestE2EThreeNode`
+- [x] Can restart nodes without data loss — `TestNodeRestart`
+
+### Recovery
+- [x] Restore from latest checkpoint works — `TestStartupCheckpointCoversLocalWAL`, `TestE2ESingleNodeS3` reopen
+- [x] Full cluster restart works — `TestE2EThreeNode`
+
+### Observability
+- [x] Basic metrics exposed — `internal/metrics/metrics.go` (Prometheus); `--metrics-addr` flag
+- [x] Logs show leader changes and WAL progress — logrus throughout
+
+---
+
+## Stage 2 — Small Production (≤ 50 nodes)
+
+### Consistency Contract (DOCUMENTED)
+- [x] Write durability definition — `docs/operations.md` (WAL sync upload, quorum ACK)
+- [x] Linearizable vs serializable reads defined — `docs/configuration.md`, `--read-consistency` flag
+- [x] Behavior under S3 failure defined — `docs/operations.md` "S3 unavailability" (cluster vs single-node, recovery)
+- [x] Behavior under network partition defined — `docs/operations.md` "Network partitions" (split-brain prevention, convergence on heal)
+
+### Failure Testing (AUTOMATED)
+- [x] Kill leader during write — `TestLeaderCrashBeforeWALFlush`
+- [x] Kill follower during commit — `TestFollowerKilledDuringCommit`
+- [x] Kill all nodes and recover — `TestE2EThreeNode`
+- [x] S3 temporarily unavailable — `TestObjectStoreUnavailableWritesSucceed`, `TestObjectStoreUnavailableRecovery`
+- [x] Network partition scenarios — `TestNetworkPartitionNoSplitBrain` (proxy-based partition, split-brain check, heal + resync)
+
+### Performance
+- [ ] Stable p95 write latency — `bench_test.go` exists but not a CI gate
+- [ ] Stable watch latency — not measured
+- [ ] No stalls under moderate concurrency — `TestLongRunningConsistency` (stress) covers basic case
+
+### Backup / Restore
+- [x] Restore CLI implemented — `strata branch fork/unfork`; `RestorePoint` in `restore.go`
+- [x] Restore tested end-to-end — `TestRestorePoint`
+- [ ] Restore from arbitrary checkpoint works — `RestorePoint` struct supports it but no CLI flag or guide
+
+### Operations
+- [x] Install documented — `docs/operations.md`
+- [x] Upgrade documented — `docs/operations.md` (add node to running cluster)
+- [x] GC / compaction documented — `docs/operations.md`
+
+---
+
+## Stage 3 — Production Ready
+
+### Reliability
+- [ ] Passes repeated chaos testing
+- [ ] No data corruption in long soak tests (≥ 1 week)
+- [ ] WAL corruption recovery tested — partial (`TestWALReplayAfterPartialUpload` covers partial upload)
+- [x] Checkpoint corruption recovery tested — `TestCheckpointCorruptionManifest`, `TestCheckpointCorruptionArchive`
+
+### Scalability Envelope (DOCUMENTED)
+- [ ] Max tested nodes: ______
+- [ ] Max tested writes/sec: ______
+- [ ] Max watchers: ______
+- [ ] Max dataset size: ______
+
+### Tail Latency
+- [ ] p99 write latency acceptable
+- [ ] p99 watch latency acceptable
+- [ ] Failover time measured and stable
+
+### Observability (ADVANCED)
+- [x] Leader / follower state metrics — `strata_role` gauge
+- [ ] Follower lag metrics — no per-follower lag metric
+- [x] WAL throughput metrics — `strata_wal_uploads_total`, `strata_wal_upload_duration_seconds`
+- [ ] S3 error + latency metrics — WAL upload errors tracked; no general S3 latency metric
+- [ ] Alerting defined
+
+### Upgrade & Compatibility
+- [ ] Backward-compatible WAL format
+- [ ] Backward-compatible checkpoint format
+- [ ] Rolling upgrade supported
+- [ ] Downgrade path defined
+
+### Security
+- [x] TLS between nodes — peer mTLS (`--peer-tls-*` flags)
+- [x] Auth for clients — etcd-compatible RBAC (`--auth-enabled`)
+- [x] Encryption for WAL/checkpoints (optional) — AES-256-GCM (`--encryption-key-file`/`--encryption-key-env`); in progress on `enc-at-rest` branch
+
+---
+
+## Stage 4 — External Users / Product
+
+### Documentation
+- [x] Architecture doc — `docs/architecture.md`
+- [ ] Consistency model doc — partial (scattered across `docs/configuration.md`)
+- [ ] Failure scenarios doc — not comprehensive; no dedicated doc
+- [ ] Backup / restore guide — no dedicated guide
+- [ ] Kubernetes integration guide — not present
+
+### Usability
+- [ ] CLI complete (backup, restore, branch, gc, status) — branch CLI done; no gc/status/backup subcommands
+- [ ] Helm chart or install script — not present
+- [ ] Minimal setup steps — `docs/operations.md` covers basics
+
+### Supportability
+- [ ] Runbooks for incidents
+- [ ] Troubleshooting guide
+- [ ] Metrics dashboard examples
+
+---
+
+## Final Production Gate
+
+Strata can be called production-ready if:
+
+- [ ] All Stage 2 requirements are complete
+- [ ] Failure scenarios are tested and reproducible
+- [ ] Restore is proven and documented
+- [ ] Consistency guarantees are explicit
+- [ ] System runs Kubernetes reliably under real workloads
+- [ ] Another engineer can deploy and recover the system using only documentation
+
+---
+
+## Notes
+
+- Performance alone does NOT define production readiness.
+- Correctness + recovery + operability are the critical factors.
+- Prefer staged rollout instead of a binary "production-ready" claim.


### PR DESCRIPTION
Add two Stage 2 failure tests:
- TestFollowerKilledDuringCommit: kills a follower mid-stream, verifies the leader + remaining follower keep accepting writes, then confirms the killed follower resyncs from S3 on rejoin with a fresh data dir.
- TestNetworkPartitionNoSplitBrain: uses a blockableProxy (TCP proxy with block/unblock) to partition a follower from the leader without killing either process; asserts no split-brain while the leader's S3 lock is fresh, then heals the partition and verifies convergence on all keys.

Expand docs/operations.md with formal S3 failure and network partition behaviour contracts (cluster vs single-node, recovery, split-brain prevention). Update strata-production-checklist.md to tick all four newly-completed Stage 2 items.