### PR TITLE
feat: add strata restore CLI and document restore workflow

### DIFF
--- a/cmd/strata/main.go
+++ b/cmd/strata/main.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -177,6 +178,7 @@ func rootCmd() *cobra.Command {
 	}
 	root.AddCommand(runCmd())
 	root.AddCommand(branchCmd())
+	root.AddCommand(restoreCmd())
 	return root
 }
 
@@ -604,4 +606,140 @@ func newS3Store(ctx context.Context, bucket, prefix, endpoint string) (*object.S
 	}
 	client := s3.NewFromConfig(awsCfg, clientOpts...)
 	return object.NewS3Store(client, bucket, prefix), nil
+}
+
+// restoreCmd returns the "strata restore" subcommand tree.
+func restoreCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "restore",
+		Short: "Inspect and restore from S3 checkpoints",
+	}
+	cmd.AddCommand(restoreListCmd())
+	cmd.AddCommand(restoreCheckpointCmd())
+	return cmd
+}
+
+// restoreListCmd lists all checkpoints available in an S3 bucket.
+func restoreListCmd() *cobra.Command {
+	var (
+		bucket   string
+		prefix   string
+		endpoint string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List checkpoints available in S3",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			store, err := newS3Store(cmd.Context(), bucket, prefix, endpoint)
+			if err != nil {
+				return fmt.Errorf("init S3: %w", err)
+			}
+			ctx := cmd.Context()
+			keys, err := checkpoint.ListRemote(ctx, store)
+			if err != nil {
+				return fmt.Errorf("list checkpoints: %w", err)
+			}
+			if len(keys) == 0 {
+				fmt.Println("No checkpoints found.")
+				return nil
+			}
+			manifest, _ := checkpoint.ReadManifest(ctx, store)
+			fmt.Printf("%-72s  %10s  %6s\n", "CHECKPOINT", "REVISION", "TERM")
+			for _, key := range keys {
+				idx, err := checkpoint.ReadCheckpointIndex(ctx, store, key)
+				suffix := ""
+				if manifest != nil && manifest.CheckpointKey == key {
+					suffix = "  (latest)"
+				}
+				if err != nil {
+					fmt.Printf("%-72s  %10s  %6s%s\n", key, "?", "?", suffix)
+				} else {
+					fmt.Printf("%-72s  %10d  %6d%s\n", key, idx.Revision, idx.Term, suffix)
+				}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&bucket, "s3-bucket", "", "S3 bucket to list (required)")
+	cmd.Flags().StringVar(&prefix, "s3-prefix", "", "key prefix inside the S3 bucket")
+	cmd.Flags().StringVar(&endpoint, "s3-endpoint", "", "custom S3 endpoint URL")
+	cmd.MarkFlagRequired("s3-bucket")
+	return cmd
+}
+
+// restoreCheckpointCmd downloads a checkpoint from S3 to a local data directory.
+func restoreCheckpointCmd() *cobra.Command {
+	var (
+		bucket        string
+		prefix        string
+		endpoint      string
+		checkpointKey string
+		dataDir       string
+	)
+	cmd := &cobra.Command{
+		Use:   "checkpoint",
+		Short: "Download a checkpoint to a local data directory",
+		Long: `Download an S3 checkpoint to a local data directory so that
+'strata run' can start from it on the next boot.
+
+By default the latest checkpoint is used. Pass --checkpoint to restore
+from a specific earlier revision (use 'strata restore list' to find keys).
+
+After this command succeeds, start the node with:
+
+  strata run --data-dir <data-dir> [--s3-bucket <bucket>] ...
+
+Configure --s3-bucket to a different prefix than the source so the
+restored node writes to its own namespace and does not overwrite the
+original cluster's data. To stay at the restored revision without
+replaying newer WAL from S3, omit --s3-bucket entirely.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			pebbleDir := filepath.Join(dataDir, "db")
+			if _, err := os.Stat(pebbleDir); err == nil {
+				return fmt.Errorf("data directory %q already contains a Pebble database; remove it first", pebbleDir)
+			}
+
+			store, err := newS3Store(cmd.Context(), bucket, prefix, endpoint)
+			if err != nil {
+				return fmt.Errorf("init S3: %w", err)
+			}
+			ctx := cmd.Context()
+
+			key := checkpointKey
+			if key == "" {
+				manifest, err := checkpoint.ReadManifest(ctx, store)
+				if err != nil {
+					return fmt.Errorf("read manifest: %w", err)
+				}
+				if manifest == nil {
+					return fmt.Errorf("no checkpoints found in s3://%s/%s", bucket, prefix)
+				}
+				key = manifest.CheckpointKey
+				logrus.Infof("using latest checkpoint: %s (rev=%d)", key, manifest.Revision)
+			}
+
+			logrus.Infof("restoring checkpoint %q → %s", key, pebbleDir)
+			term, rev, err := checkpoint.Restore(ctx, store, key, pebbleDir)
+			if err != nil {
+				return fmt.Errorf("restore checkpoint: %w", err)
+			}
+
+			fmt.Printf("Restored checkpoint\n")
+			fmt.Printf("  key:       %s\n", key)
+			fmt.Printf("  revision:  %d\n", rev)
+			fmt.Printf("  term:      %d\n", term)
+			fmt.Printf("  data-dir:  %s\n", dataDir)
+			fmt.Printf("\nStart the restored node:\n")
+			fmt.Printf("  strata run --data-dir %s [--s3-bucket <new-bucket>] --listen 0.0.0.0:3379\n", dataDir)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&bucket, "s3-bucket", "", "S3 bucket containing the checkpoint (required)")
+	cmd.Flags().StringVar(&prefix, "s3-prefix", "", "key prefix inside the S3 bucket")
+	cmd.Flags().StringVar(&endpoint, "s3-endpoint", "", "custom S3 endpoint URL")
+	cmd.Flags().StringVar(&checkpointKey, "checkpoint", "", "checkpoint key to restore (default: latest; use 'strata restore list' to find keys)")
+	cmd.Flags().StringVar(&dataDir, "data-dir", "", "local directory to restore into (required; must not already contain a Pebble database)")
+	cmd.MarkFlagRequired("s3-bucket")
+	cmd.MarkFlagRequired("data-dir")
+	return cmd
 }

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -485,6 +485,105 @@ While followers are disconnected, the leader's `WaitForFollowers` returns immedi
 
 ---
 
+## Restore from checkpoint
+
+`strata restore` lets you inspect available checkpoints and download one to a local data directory so that `strata run` can boot from it.
+
+### Listing checkpoints
+
+```bash
+strata restore list \
+  --s3-bucket my-bucket \
+  --s3-prefix strata/
+```
+
+Output:
+
+```
+CHECKPOINT                                                                  REVISION    TERM
+checkpoint/0000000001/00000000000000000050/manifest.json                          50       1
+checkpoint/0000000001/00000000000000000100/manifest.json                         100       1  (latest)
+```
+
+### Restoring a checkpoint
+
+```bash
+# Restore the latest checkpoint (default).
+strata restore checkpoint \
+  --s3-bucket my-bucket \
+  --s3-prefix strata/ \
+  --data-dir /var/lib/strata-restored
+
+# Restore a specific earlier revision.
+strata restore checkpoint \
+  --s3-bucket my-bucket \
+  --s3-prefix strata/ \
+  --checkpoint checkpoint/0000000001/00000000000000000050/manifest.json \
+  --data-dir /var/lib/strata-restored
+```
+
+The command downloads all SST files and Pebble metadata to `<data-dir>/db/` and prints a summary:
+
+```
+Restored checkpoint
+  key:       checkpoint/0000000001/00000000000000000050/manifest.json
+  revision:  50
+  term:      1
+  data-dir:  /var/lib/strata-restored
+
+Start the restored node:
+  strata run --data-dir /var/lib/strata-restored [--s3-bucket <new-bucket>] --listen 0.0.0.0:3379
+```
+
+### Starting the restored node
+
+After the download, run the node pointing at the prepared data directory:
+
+```bash
+# Inspect the restored state without connecting to S3 (stays at the restored revision).
+strata run \
+  --data-dir /var/lib/strata-restored \
+  --listen   0.0.0.0:3379
+
+# Or write to a separate S3 prefix so the restored node has its own durable history.
+# The node opens the local Pebble database, then replays any WAL segments in
+# <new-prefix> that are newer than the restored revision.
+strata run \
+  --data-dir  /var/lib/strata-restored \
+  --s3-bucket my-bucket \
+  --s3-prefix strata-restored/ \
+  --listen    0.0.0.0:3379
+```
+
+> **Note:** If you point `--s3-bucket/prefix` at the **original** cluster's prefix, the node will replay all WAL segments written after the restored checkpoint and arrive at the current state — this is recovery, not a rollback. To stay at the past revision, omit `--s3-bucket` or use a different prefix.
+
+### Point-in-time recovery workflow
+
+```bash
+# 1. Find the last good checkpoint.
+strata restore list --s3-bucket my-bucket --s3-prefix strata/
+
+# 2. Download it to a local directory.
+strata restore checkpoint \
+  --s3-bucket my-bucket --s3-prefix strata/ \
+  --checkpoint checkpoint/0000000001/00000000000000000050/manifest.json \
+  --data-dir /var/lib/strata-pitr
+
+# 3. Start a verification node (no S3 → stays at rev 50).
+strata run --data-dir /var/lib/strata-pitr --listen 0.0.0.0:3380
+
+# 4. Validate. If correct, promote by starting with a new S3 prefix.
+strata run \
+  --data-dir  /var/lib/strata-pitr \
+  --s3-bucket my-bucket \
+  --s3-prefix strata-recovered/ \
+  --listen    0.0.0.0:3379
+```
+
+For zero-copy forking (no SST downloads) use `strata branch fork` instead — see [Branching](#branching).
+
+---
+
 ## Branching
 
 Branches let you fork a database at any checkpoint with zero S3 data copies. SST files are content-addressed and shared between the source and all branches — no data is duplicated.

--- a/strata-production-checklist.md
+++ b/strata-production-checklist.md
@@ -52,7 +52,7 @@ It is divided into stages and clear pass/fail requirements.
 ### Backup / Restore
 - [x] Restore CLI implemented — `strata branch fork/unfork`; `RestorePoint` in `restore.go`
 - [x] Restore tested end-to-end — `TestRestorePoint`
-- [ ] Restore from arbitrary checkpoint works — `RestorePoint` struct supports it but no CLI flag or guide
+- [x] Restore from arbitrary checkpoint works — `strata restore list` + `strata restore checkpoint`; documented in `docs/operations.md`
 
 ### Operations
 - [x] Install documented — `docs/operations.md`


### PR DESCRIPTION
Add two new subcommands under 'strata restore':
- 'strata restore list'       — lists all checkpoints in S3 with their
  revision, term, and which is the latest (marked with '(latest)')
- 'strata restore checkpoint' — downloads a specific (or latest)
  checkpoint to a local data directory ready for 'strata run'

Both commands accept --s3-bucket, --s3-prefix, --s3-endpoint. 'restore checkpoint' takes an optional --checkpoint key (defaults to latest) and a required --data-dir (fails if pebble dir already exists).

Add a 'Restore from checkpoint' section to docs/operations.md covering:
- listing checkpoints, downloading them, starting the restored node
- the distinction between recovery (replay newer WAL) vs point-in-time restore (new prefix or no S3)
- a full point-in-time recovery workflow example
- when to use branching instead (zero-copy, no SST downloads)

Ticks the Stage 2 'Restore from arbitrary checkpoint' checklist item.