### PR TITLE
feat: add S3 operation metrics via instrumented store wrapper

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -118,6 +118,19 @@ var (
 		Name: "strata_follower_lag_revisions",
 		Help: "Number of revisions the follower is behind the leader (0 = fully caught up).",
 	}, []string{"follower_id"})
+
+	// ObjectStoreOpsTotal counts object storage operations by op type and result.
+	ObjectStoreOpsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "strata_object_store_ops_total",
+		Help: "Total object storage operations by op (get/put/delete/list/get_etag/put_if_absent/put_if_match) and result (success/error).",
+	}, []string{"op", "result"})
+
+	// ObjectStoreDuration measures object storage operation latency by op type.
+	ObjectStoreDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "strata_object_store_duration_seconds",
+		Help:    "Object storage operation latency.",
+		Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+	}, []string{"op"})
 )
 
 // SetRole updates the role gauges so exactly one has value 1.

--- a/node.go
+++ b/node.go
@@ -160,6 +160,13 @@ func (n *Node) storeRole(r nodeRole) { n.role.Store(int32(r)) }
 func Open(cfg Config) (*Node, error) {
 	cfg.setDefaults()
 
+	// Wrap the object store with Prometheus instrumentation so every S3
+	// operation is counted and timed without scattering metrics calls
+	// throughout the codebase.
+	if cfg.ObjectStore != nil {
+		cfg.ObjectStore = object.NewInstrumentedStore(cfg.ObjectStore)
+	}
+
 	pebbleDir := filepath.Join(cfg.DataDir, "db")
 	walDir := filepath.Join(cfg.DataDir, "wal")
 

--- a/pkg/object/instrumented.go
+++ b/pkg/object/instrumented.go
@@ -1,0 +1,91 @@
+package object
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/strata-db/strata/internal/metrics"
+)
+
+// instrumentedStore wraps a Store and records Prometheus metrics for every
+// operation: strata_object_store_ops_total{op, result} and
+// strata_object_store_duration_seconds{op}.
+type instrumentedStore struct{ inner Store }
+
+// instrumentedConditionalStore additionally implements ConditionalStore.
+type instrumentedConditionalStore struct {
+	instrumentedStore
+	inner ConditionalStore
+}
+
+// NewInstrumentedStore wraps s with metrics instrumentation. If s also
+// implements ConditionalStore the returned value implements it too, so
+// callers that type-assert to ConditionalStore continue to work.
+func NewInstrumentedStore(s Store) Store {
+	if cs, ok := s.(ConditionalStore); ok {
+		return &instrumentedConditionalStore{
+			instrumentedStore: instrumentedStore{inner: s},
+			inner:             cs,
+		}
+	}
+	return &instrumentedStore{inner: s}
+}
+
+func record(op string, start time.Time, err error) {
+	result := "success"
+	if err != nil {
+		result = "error"
+	}
+	metrics.ObjectStoreOpsTotal.WithLabelValues(op, result).Inc()
+	metrics.ObjectStoreDuration.WithLabelValues(op).Observe(time.Since(start).Seconds())
+}
+
+func (s *instrumentedStore) Put(ctx context.Context, key string, r io.Reader) error {
+	start := time.Now()
+	err := s.inner.Put(ctx, key, r)
+	record("put", start, err)
+	return err
+}
+
+func (s *instrumentedStore) Get(ctx context.Context, key string) (io.ReadCloser, error) {
+	start := time.Now()
+	rc, err := s.inner.Get(ctx, key)
+	record("get", start, err)
+	return rc, err
+}
+
+func (s *instrumentedStore) Delete(ctx context.Context, key string) error {
+	start := time.Now()
+	err := s.inner.Delete(ctx, key)
+	record("delete", start, err)
+	return err
+}
+
+func (s *instrumentedStore) List(ctx context.Context, prefix string) ([]string, error) {
+	start := time.Now()
+	keys, err := s.inner.List(ctx, prefix)
+	record("list", start, err)
+	return keys, err
+}
+
+func (s *instrumentedConditionalStore) GetETag(ctx context.Context, key string) (*GetWithETag, error) {
+	start := time.Now()
+	res, err := s.inner.GetETag(ctx, key)
+	record("get_etag", start, err)
+	return res, err
+}
+
+func (s *instrumentedConditionalStore) PutIfAbsent(ctx context.Context, key string, r io.Reader) error {
+	start := time.Now()
+	err := s.inner.PutIfAbsent(ctx, key, r)
+	record("put_if_absent", start, err)
+	return err
+}
+
+func (s *instrumentedConditionalStore) PutIfMatch(ctx context.Context, key string, r io.Reader, matchETag string) error {
+	start := time.Now()
+	err := s.inner.PutIfMatch(ctx, key, r, matchETag)
+	record("put_if_match", start, err)
+	return err
+}


### PR DESCRIPTION
Wrap cfg.ObjectStore with object.NewInstrumentedStore in Open() so every S3 call (get/put/delete/list and conditional variants) emits:
  strata_object_store_ops_total{op, result}   — counter
  strata_object_store_duration_seconds{op}    — histogram

The wrapper preserves ConditionalStore when the underlying store supports it, so leader-election CAS ops continue to work. Tick the S3 metrics checklist item and add the new metrics to the operations.md table.