### PR TITLE
Fix node stream cleanup on quick reconnect

### DIFF
--- a/internal/peer/server.go
+++ b/internal/peer/server.go
@@ -311,28 +311,34 @@ func (s *Server) Follow(req *FollowRequest, stream WalStream_FollowServer) error
 	s.mu.Unlock()
 
 	defer func() {
-		s.mu.Lock()
-		delete(s.followers, req.NodeID)
-		delete(s.followerAckRevs, req.NodeID)
+		owned := false
 		graceful := false
-		if _, ok := s.gracefulGoodbyes[req.NodeID]; ok {
-			delete(s.gracefulGoodbyes, req.NodeID)
-			graceful = true
-		}
-		// Only trigger split-brain fencing for unexpected disconnects.
-		// A graceful GoodBye means the follower is shutting down intentionally
-		// and will not attempt a TakeOver.
-		if !graceful {
-			select {
-			case s.DisconnectC <- struct{}{}:
-			default:
+		s.mu.Lock()
+		if cur, ok := s.followers[req.NodeID]; ok && cur == ch {
+			owned = true
+			delete(s.followers, req.NodeID)
+			delete(s.followerAckRevs, req.NodeID)
+			if _, ok := s.gracefulGoodbyes[req.NodeID]; ok {
+				delete(s.gracefulGoodbyes, req.NodeID)
+				graceful = true
+			}
+			// Only trigger split-brain fencing for unexpected disconnects.
+			// A graceful GoodBye means the follower is shutting down intentionally
+			// and will not attempt a TakeOver.
+			if !graceful {
+				select {
+				case s.DisconnectC <- struct{}{}:
+				default:
+				}
 			}
 		}
 		s.mu.Unlock()
-		// Remove the lag metric so disconnected followers don't linger in dashboards.
-		metrics.FollowerLag.DeleteLabelValues(req.NodeID)
-		// Wake WaitForFollowers: this follower is no longer required.
-		s.notifyACK()
+		if owned {
+			// Remove the lag metric so disconnected followers don't linger in dashboards.
+			metrics.FollowerLag.DeleteLabelValues(req.NodeID)
+			// Wake WaitForFollowers: this follower is no longer required.
+			s.notifyACK()
+		}
 	}()
 
 	s.log.Infof("peer: follower %q connected (fromRev=%d, snapshot=%d entries)", req.NodeID, req.FromRevision, len(snapshot))
@@ -347,6 +353,10 @@ func (s *Server) Follow(req *FollowRequest, stream WalStream_FollowServer) error
 				return // stream closed or context done
 			}
 			s.mu.Lock()
+			if cur, ok := s.followers[req.NodeID]; !ok || cur != ch {
+				s.mu.Unlock()
+				return
+			}
 			if ack.Revision > s.followerAckRevs[req.NodeID] {
 				s.followerAckRevs[req.NodeID] = ack.Revision
 			}

--- a/internal/peer/server_wait_test.go
+++ b/internal/peer/server_wait_test.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc/metadata"
+
+	"github.com/t4db/t4/internal/wal"
 )
 
 func TestWaitForFollowersNoneReturnsImmediately(t *testing.T) {
@@ -126,5 +130,126 @@ func TestWaitForFollowersAllReturnsWhenRemainingFollowersDisconnect(t *testing.T
 		}
 	case <-ctx.Done():
 		t.Fatal("timeout waiting for disconnect completion")
+	}
+}
+
+type fakeFollowStream struct {
+	ctx   context.Context
+	sendC chan *WalEntryMsg
+}
+
+func newFakeFollowStream(ctx context.Context) *fakeFollowStream {
+	return &fakeFollowStream{
+		ctx:   ctx,
+		sendC: make(chan *WalEntryMsg, 32),
+	}
+}
+
+func (f *fakeFollowStream) SetHeader(metadata.MD) error  { return nil }
+func (f *fakeFollowStream) SendHeader(metadata.MD) error { return nil }
+func (f *fakeFollowStream) SetTrailer(metadata.MD)       {}
+func (f *fakeFollowStream) Context() context.Context     { return f.ctx }
+
+func (f *fakeFollowStream) SendMsg(m interface{}) error {
+	msg, _ := m.(*WalEntryMsg)
+	return f.Send(msg)
+}
+
+func (f *fakeFollowStream) RecvMsg(_ interface{}) error {
+	<-f.ctx.Done()
+	return f.ctx.Err()
+}
+
+func (f *fakeFollowStream) Send(msg *WalEntryMsg) error {
+	select {
+	case f.sendC <- msg:
+		return nil
+	case <-f.ctx.Done():
+		return f.ctx.Err()
+	}
+}
+
+func waitForStreamMessage(t *testing.T, ch <-chan *WalEntryMsg, pred func(*WalEntryMsg) bool, timeout time.Duration, desc string) *WalEntryMsg {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case msg := <-ch:
+			if pred(msg) {
+				return msg
+			}
+		case <-deadline:
+			t.Fatalf("timeout waiting for %s", desc)
+		}
+	}
+}
+
+func TestFollowCleanupDoesNotDropReplacementFollower(t *testing.T) {
+	srv := NewServer(16, nil)
+	for rev := int64(1); rev <= 3; rev++ {
+		srv.Broadcast(&wal.Entry{
+			Revision:       rev,
+			Term:           1,
+			Op:             wal.OpCreate,
+			Key:            "/k",
+			Value:          []byte("v"),
+			CreateRevision: rev,
+		})
+	}
+	srv.BroadcastCommit(1, 3)
+
+	oldCtx, oldCancel := context.WithCancel(t.Context())
+	defer oldCancel()
+	oldStream := newFakeFollowStream(oldCtx)
+	oldErrCh := make(chan error, 1)
+	go func() {
+		oldErrCh <- srv.Follow(&FollowRequest{FromRevision: 1, NodeID: "f1"}, oldStream)
+	}()
+	waitForStreamMessage(t, oldStream.sendC, func(msg *WalEntryMsg) bool {
+		return !msg.Commit && msg.Revision == 1
+	}, time.Second, "old follower snapshot")
+
+	newCtx, newCancel := context.WithCancel(t.Context())
+	defer newCancel()
+	newStream := newFakeFollowStream(newCtx)
+	newErrCh := make(chan error, 1)
+	go func() {
+		newErrCh <- srv.Follow(&FollowRequest{FromRevision: 2, NodeID: "f1"}, newStream)
+	}()
+	waitForStreamMessage(t, newStream.sendC, func(msg *WalEntryMsg) bool {
+		return !msg.Commit && msg.Revision == 2
+	}, time.Second, "replacement follower snapshot")
+
+	// Now that the replacement stream is registered, let the original stream
+	// exit. Its deferred cleanup must not delete the replacement follower.
+	oldCancel()
+	select {
+	case <-oldErrCh:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for original stream to exit")
+	}
+
+	srv.Broadcast(&wal.Entry{
+		Revision:       4,
+		Term:           1,
+		Op:             wal.OpCreate,
+		Key:            "/k2",
+		Value:          []byte("v"),
+		CreateRevision: 4,
+	})
+	srv.BroadcastCommit(4, 4)
+
+	waitForStreamMessage(t, newStream.sendC, func(msg *WalEntryMsg) bool {
+		return !msg.Commit && msg.Revision == 4
+	}, time.Second, "replacement follower live entry")
+	waitForStreamMessage(t, newStream.sendC, func(msg *WalEntryMsg) bool {
+		return msg.Commit && msg.CommitStartRevision == 4 && msg.CommitRevision == 4
+	}, time.Second, "replacement follower live commit")
+
+	newCancel()
+	select {
+	case <-newErrCh:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for replacement stream to exit")
 	}
 }


### PR DESCRIPTION
When a follower reconnected quickly with the same NodeID, the old stream’s deferred cleanup could run after the new stream had already registered. That old cleanup unconditionally deleted `s.followers[req.NodeID]`, which removed the new active stream from the leader’s follower map. As a result, the new stream stayed open but stopped receiving live entries.
