### PR TITLE
Watch fixes and improvements

### DIFF
--- a/etcd/e2e_test.go
+++ b/etcd/e2e_test.go
@@ -147,7 +147,7 @@ func basicCRUD(t *testing.T, cli *clientv3.Client) {
 	// Watch.
 	watchCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
-	wch := cli.Watch(watchCtx, "/smoke/watch/")
+	wch := cli.Watch(watchCtx, "/smoke/watch/", clientv3.WithPrefix())
 	go func() { cli.Put(watchCtx, "/smoke/watch/key", "event") }()
 	select {
 	case wr := <-wch:

--- a/etcd/watch.go
+++ b/etcd/watch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"time"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
@@ -32,6 +33,15 @@ func (s *Server) Watch(stream etcdserverpb.Watch_WatchServer) error {
 	var watchesMu sync.Mutex
 	watches := map[int64]entry{}
 	var nextID int64 = 1
+	watchIDs := func() []int64 {
+		watchesMu.Lock()
+		ids := make([]int64, 0, len(watches))
+		for id := range watches {
+			ids = append(ids, id)
+		}
+		watchesMu.Unlock()
+		return ids
+	}
 	removeWatch := func(id int64) (context.CancelFunc, bool) {
 		watchesMu.Lock()
 		w, ok := watches[id]
@@ -84,7 +94,8 @@ func (s *Server) Watch(stream etcdserverpb.Watch_WatchServer) error {
 			}
 
 			go func(watchID int64, startRev int64) {
-				events, err := s.node.Watch(wctx, string(cr.Key), fromEtcdRevision(startRev))
+				scanPrefix, match := watchScan(cr)
+				events, err := s.node.Watch(wctx, scanPrefix, fromEtcdRevision(startRev))
 				if errors.Is(err, t4.ErrCompacted) {
 					// Remove the watch first, but do not cancel wctx before sending
 					// the compacted response: that races the select below and can
@@ -105,18 +116,44 @@ func (s *Server) Watch(stream etcdserverpb.Watch_WatchServer) error {
 				if err != nil {
 					return
 				}
-				for e := range events {
-					e, ok := userEvent(e)
-					if !ok {
-						continue
-					}
-					resp := &etcdserverpb.WatchResponse{
-						Header:  s.header(),
-						WatchId: watchID,
-						Events:  []*mvccpb.Event{eventToProto(e)},
-					}
+
+				var progressC <-chan time.Time
+				var progressTicker *time.Ticker
+				if cr.ProgressNotify {
+					progressTicker = time.NewTicker(time.Second)
+					progressC = progressTicker.C
+					defer progressTicker.Stop()
+				}
+
+				for {
 					select {
-					case sendCh <- resp:
+					case e, ok := <-events:
+						if !ok {
+							return
+						}
+						if !match(e.KV.Key) {
+							continue
+						}
+						e, ok = userEvent(e)
+						if !ok {
+							continue
+						}
+						resp := &etcdserverpb.WatchResponse{
+							Header:  s.header(),
+							WatchId: watchID,
+							Events:  []*mvccpb.Event{eventToProto(e)},
+						}
+						select {
+						case sendCh <- resp:
+						case <-wctx.Done():
+							return
+						}
+					case <-progressC:
+						select {
+						case sendCh <- &etcdserverpb.WatchResponse{Header: s.header(), WatchId: watchID}:
+						case <-wctx.Done():
+							return
+						}
 					case <-wctx.Done():
 						return
 					}
@@ -129,6 +166,14 @@ func (s *Server) Watch(stream etcdserverpb.Watch_WatchServer) error {
 				cancel()
 				select {
 				case sendCh <- &etcdserverpb.WatchResponse{Header: s.header(), WatchId: id, Canceled: true}:
+				case <-ctx.Done():
+					goto done
+				}
+			}
+		case *etcdserverpb.WatchRequest_ProgressRequest:
+			for _, id := range watchIDs() {
+				select {
+				case sendCh <- &etcdserverpb.WatchResponse{Header: s.header(), WatchId: id}:
 				case <-ctx.Done():
 					goto done
 				}
@@ -148,4 +193,37 @@ done:
 		w.cancel()
 	}
 	return nil
+}
+
+func watchScan(cr *etcdserverpb.WatchCreateRequest) (string, func(string) bool) {
+	key := string(cr.Key)
+	end := string(cr.RangeEnd)
+	if end == "" {
+		return key, func(candidate string) bool { return candidate == key }
+	}
+	match := func(candidate string) bool {
+		if end == "\x00" {
+			return candidate >= key
+		}
+		return candidate >= key && candidate < end
+	}
+	if isPrefixRangeEnd(key, end) {
+		return key, match
+	}
+	return "", match
+}
+
+func isPrefixRangeEnd(prefix, end string) bool {
+	return prefixRangeEnd(prefix) == end
+}
+
+func prefixRangeEnd(prefix string) string {
+	b := []byte(prefix)
+	for i := len(b) - 1; i >= 0; i-- {
+		if b[i] < 0xff {
+			b[i]++
+			return string(b[:i+1])
+		}
+	}
+	return "\x00"
 }

--- a/etcd/watch_test.go
+++ b/etcd/watch_test.go
@@ -120,6 +120,123 @@ func TestWatchNonMatchingPrefix(t *testing.T) {
 	}
 }
 
+func TestWatchExactKeyDoesNotActLikePrefix(t *testing.T) {
+	node, cli := newWatchNode(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wch := cli.Watch(ctx, "/exact/key")
+	if _, err := node.Put(ctx, "/exact/key-child", []byte("wrong"), 0); err != nil {
+		t.Fatalf("Put child: %v", err)
+	}
+	if _, err := node.Put(ctx, "/exact/key", []byte("right"), 0); err != nil {
+		t.Fatalf("Put exact: %v", err)
+	}
+
+	for {
+		select {
+		case wr := <-wch:
+			if err := wr.Err(); err != nil {
+				t.Fatalf("watch error: %v", err)
+			}
+			for _, ev := range wr.Events {
+				if string(ev.Kv.Key) == "/exact/key-child" {
+					t.Fatal("exact watch received prefix child event")
+				}
+				if string(ev.Kv.Key) == "/exact/key" {
+					return
+				}
+			}
+		case <-ctx.Done():
+			t.Fatal("timeout waiting for exact watch event")
+		}
+	}
+}
+
+func TestWatchRangeEndFiltersInterval(t *testing.T) {
+	node, cli := newWatchNode(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wch := cli.Watch(ctx, "/range/b", clientv3.WithRange("/range/d"))
+	for _, key := range []string{"/range/a", "/range/b", "/range/c", "/range/d"} {
+		if _, err := node.Put(ctx, key, []byte("v"), 0); err != nil {
+			t.Fatalf("Put(%q): %v", key, err)
+		}
+	}
+
+	seen := map[string]bool{}
+	for len(seen) < 2 {
+		select {
+		case wr := <-wch:
+			if err := wr.Err(); err != nil {
+				t.Fatalf("watch error: %v", err)
+			}
+			for _, ev := range wr.Events {
+				key := string(ev.Kv.Key)
+				if key == "/range/a" || key == "/range/d" {
+					t.Fatalf("range watch received out-of-range key %q", key)
+				}
+				seen[key] = true
+			}
+		case <-ctx.Done():
+			t.Fatalf("timeout waiting for range watch events, seen=%v", seen)
+		}
+	}
+	if !seen["/range/b"] || !seen["/range/c"] {
+		t.Fatalf("range watch missed expected keys: %v", seen)
+	}
+}
+
+func TestWatchProgressNotify(t *testing.T) {
+	_, cli := newWatchNode(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wch := cli.Watch(ctx, "/progress/key", clientv3.WithProgressNotify())
+	for {
+		select {
+		case wr := <-wch:
+			if err := wr.Err(); err != nil {
+				t.Fatalf("watch error: %v", err)
+			}
+			if wr.IsProgressNotify() {
+				if wr.Header.GetRevision() == 0 {
+					t.Fatal("progress notify returned revision 0")
+				}
+				return
+			}
+		case <-ctx.Done():
+			t.Fatal("timeout waiting for progress notification")
+		}
+	}
+}
+
+func TestWatchRequestProgress(t *testing.T) {
+	_, cli := newWatchNode(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wch := cli.Watch(ctx, "/progress/request")
+	if err := cli.RequestProgress(ctx); err != nil {
+		t.Fatalf("RequestProgress: %v", err)
+	}
+
+	for {
+		select {
+		case wr := <-wch:
+			if err := wr.Err(); err != nil {
+				t.Fatalf("watch error: %v", err)
+			}
+			if wr.IsProgressNotify() {
+				return
+			}
+		case <-ctx.Done():
+			t.Fatal("timeout waiting for requested progress notification")
+		}
+	}
+}
+
 // TestWatchMultipleConcurrent verifies multiple simultaneous watches each
 // receive only their own events.
 func TestWatchMultipleConcurrent(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -442,8 +442,14 @@ func (s *Store) waitChan() <-chan struct{} {
 // WaitForRevision blocks until currentRev >= rev, ctx is cancelled, or the
 // store is closed.
 func (s *Store) WaitForRevision(ctx context.Context, rev int64) error {
-	for atomic.LoadInt64(&s.currentRev) < rev {
+	for {
+		// Snapshot the notify channel before re-checking currentRev. If a
+		// broadcast races between the load and the select, ch is already
+		// closed and the select returns immediately — no lost wakeup.
 		ch := s.waitChan()
+		if atomic.LoadInt64(&s.currentRev) >= rev {
+			return nil
+		}
 		select {
 		case <-ch:
 		case <-s.closed:
@@ -452,7 +458,6 @@ func (s *Store) WaitForRevision(ctx context.Context, rev int64) error {
 			return ctx.Err()
 		}
 	}
-	return nil
 }
 
 // --- Read path ---

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -395,3 +395,42 @@ func TestWaitForRevision(t *testing.T) {
 		t.Error("timeout")
 	}
 }
+
+// TestWaitForRevisionConcurrent stresses many waiters racing against an Apply
+// that satisfies their target revision. With the lost-wakeup bug, a waiter
+// could read the new notify channel after broadcast already fired and block
+// indefinitely on it. The race window is narrow so this test is probabilistic;
+// it serves as a smoke check that the wait path stays sane under contention.
+func TestWaitForRevisionConcurrent(t *testing.T) {
+	const iters = 500
+	const waiters = 32
+
+	for i := 0; i < iters; i++ {
+		s := openMem(t)
+		targetRev := int64(1)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+
+		errs := make(chan error, waiters)
+		for w := 0; w < waiters; w++ {
+			go func() { errs <- s.WaitForRevision(ctx, targetRev) }()
+		}
+
+		apply(t, s, createEntry(targetRev, "k", nil))
+
+		for w := 0; w < waiters; w++ {
+			select {
+			case err := <-errs:
+				if err != nil {
+					cancel()
+					t.Fatalf("iter %d waiter %d: %v", i, w, err)
+				}
+			case <-ctx.Done():
+				cancel()
+				t.Fatalf("iter %d: lost wakeup — %d/%d waiters returned",
+					i, w, waiters)
+			}
+		}
+		cancel()
+	}
+}


### PR DESCRIPTION
- closing potential race window between reading currentRev and waitChan() 
- respecting `RangeEnd` in the watch request