### PR TITLE
DB size docs

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2,7 +2,8 @@
 
 ## Single-node with S3
 
-The simplest durable deployment. A single node writes WAL segments and checkpoints to S3. If the node is replaced or its disk is lost, it recovers automatically on the next start.
+The simplest durable deployment. A single node writes WAL segments and checkpoints to S3. If the node is replaced or its
+disk is lost, it recovers automatically on the next start.
 
 ```bash
 t4 run \
@@ -34,7 +35,8 @@ Multi-node mode requires:
 1. A shared S3 bucket (leader election lock + WAL archive).
 2. Each node has a unique `--node-id` and a `--peer-listen` address reachable by all other nodes.
 
-All nodes run the same command. At startup they race to acquire the S3 leader lock; the winner becomes the leader, the rest become followers.
+All nodes run the same command. At startup they race to acquire the S3 leader lock; the winner becomes the leader, the
+rest become followers.
 
 ### Three-node example
 
@@ -64,13 +66,26 @@ t4 run \
 
 ### Leader election and failover
 
-- On startup each node reads the S3 lock. If absent, it issues an **atomic conditional PUT** (`If-None-Match: *`); only one concurrent writer wins. The winner becomes the leader and records `LastSeenNano = now()` in the lock so followers see it as immediately alive.
-- The leader streams WAL entries to all followers over the peer port (default 3380). Followers apply entries and serve local reads.
-- A follower that observes `--follower-max-retries` consecutive stream failures (~10 s at default 5 × 2 s) checks the lock's `LastSeenNano`. If stale (older than `LeaderLivenessTTL` = 6 s), it attempts a takeover using `If-Match: <etag>` — only the candidate that read the same ETag wins the race. The new leader records its own address and `LastSeenNano`.
-- The former leader periodically re-reads the S3 lock (`--leader-watch-interval-sec`, default 300 s) and on every follower disconnect. Each check reads the lock **with its ETag**, then — if still the owner — writes a liveness touch using `If-Match: <etag>`. If the conditional touch is rejected (`ErrPreconditionFailed`), a new leader has taken over between the Read and the Touch: the old leader steps down immediately. This closes the Read→Touch split-brain race without a second round-trip.
+- On startup each node reads the S3 lock. If absent, it issues an **atomic conditional PUT** (`If-None-Match: *`); only
+  one concurrent writer wins. The winner becomes the leader and records `LastSeenNano = now()` in the lock so followers
+  see it as immediately alive.
+- The leader streams WAL entries to all followers over the peer port (default 3380). Followers apply entries and serve
+  local reads.
+- A follower that observes `--follower-max-retries` consecutive stream failures (~10 s at default 5 × 2 s) checks the
+  lock's `LastSeenNano`. If stale (older than `LeaderLivenessTTL` = 6 s), it attempts a takeover using
+  `If-Match: <etag>` — only the candidate that read the same ETag wins the race. The new leader records its own address
+  and `LastSeenNano`.
+- The former leader periodically re-reads the S3 lock (`--leader-watch-interval-sec`, default 300 s) and on every
+  follower disconnect. Each check reads the lock **with its ETag**, then — if still the owner — writes a liveness touch
+  using `If-Match: <etag>`. If the conditional touch is rejected (`ErrPreconditionFailed`), a new leader has taken over
+  between the Read and the Touch: the old leader steps down immediately. This closes the Read→Touch split-brain race
+  without a second round-trip.
 - Writes sent to a follower are automatically forwarded to the current leader and the result is returned to the caller.
 
-Leader election uses atomic conditional PUT (`If-None-Match`/`If-Match` on the `leader-lock` object). There is no TTL polling — the only S3 election writes are at startup, on leader takeover, and during liveness touches while followers are disconnected. In cluster mode, writes additionally require quorum ACK from all connected followers before returning to the caller.
+Leader election uses atomic conditional PUT (`If-None-Match`/`If-Match` on the `leader-lock` object). There is no TTL
+polling — the only S3 election writes are at startup, on leader takeover, and during liveness touches while followers
+are disconnected. In cluster mode, writes additionally require quorum ACK from all connected followers before returning
+to the caller.
 
 ### Adding a node to a running cluster
 
@@ -85,7 +100,8 @@ No manual registration or cluster membership changes are required.
 
 ### Scaling down
 
-Close the nodes you want to remove. The remaining nodes continue without any configuration change. If the leader is among the removed nodes, a follower will take over.
+Close the nodes you want to remove. The remaining nodes continue without any configuration change. If the leader is
+among the removed nodes, a follower will take over.
 
 ---
 
@@ -101,7 +117,8 @@ t4 run \
   --peer-tls-key  /etc/t4/tls/node.key
 ```
 
-Both the leader's gRPC server and the follower's gRPC client use these files. The same CA must be used on all nodes. TLS 1.3 is required; mutual authentication is enforced.
+Both the leader's gRPC server and the follower's gRPC client use these files. The same CA must be used on all nodes. TLS
+1.3 is required; mutual authentication is enforced.
 
 ### Embedded library
 
@@ -111,9 +128,9 @@ Pass `credentials.TransportCredentials` directly:
 serverCreds, clientCreds, err := buildTLS(caFile, certFile, keyFile)
 
 node, err := t4.Open(t4.Config{
-    ...
-    PeerServerTLS: serverCreds,
-    PeerClientTLS: clientCreds,
+...
+PeerServerTLS: serverCreds,
+PeerClientTLS: clientCreds,
 })
 ```
 
@@ -132,7 +149,8 @@ t4 run \
   --client-tls-key  /etc/t4/tls/server.key
 ```
 
-Clients connect with TLS but are not required to present a certificate. Use this when clients are etcd-compatible tools or libraries that support TLS but not mTLS.
+Clients connect with TLS but are not required to present a certificate. Use this when clients are etcd-compatible tools
+or libraries that support TLS but not mTLS.
 
 ```bash
 etcdctl --endpoints=https://localhost:3379 \
@@ -166,7 +184,10 @@ Client TLS and peer mTLS are independent — each uses its own cert/key/CA and c
 
 ## Authentication and RBAC
 
-T4 implements the etcd v3 Auth API: username/password authentication with bearer tokens, and role-based access control scoped to key prefixes. Auth state (users, roles, enabled flag) is stored in Pebble and flows through the WAL, so it is replicated to followers and included in S3 checkpoints. Bearer tokens are persisted to Pebble and survive node restarts — clients do not need to re-authenticate after a restart.
+T4 implements the etcd v3 Auth API: username/password authentication with bearer tokens, and role-based access control
+scoped to key prefixes. Auth state (users, roles, enabled flag) is stored in Pebble and flows through the WAL, so it is
+replicated to followers and included in S3 checkpoints. Bearer tokens are persisted to Pebble and survive node
+restarts — clients do not need to re-authenticate after a restart.
 
 Enable auth with `--auth-enabled`:
 
@@ -188,7 +209,8 @@ ETCDCTL_API=3 etcdctl --endpoints=localhost:3379 user add root
 ETCDCTL_API=3 etcdctl --endpoints=localhost:3379 auth enable
 ```
 
-Once enabled, all KV and Watch requests require a valid bearer token. The `root` user has unconditional access to all keys via the built-in `root` role.
+Once enabled, all KV and Watch requests require a valid bearer token. The `root` user has unconditional access to all
+keys via the built-in `root` role.
 
 > **Note:** The `root` user and `root` role cannot be deleted while auth is enabled.
 
@@ -200,7 +222,8 @@ ETCDCTL_API=3 etcdctl --endpoints=localhost:3379 \
   put /hello world
 ```
 
-The etcd client library handles token acquisition and refresh automatically when `--user` is provided. Tokens expire after `--token-ttl` seconds; the client re-authenticates transparently.
+The etcd client library handles token acquisition and refresh automatically when `--user` is provided. Tokens expire
+after `--token-ttl` seconds; the client re-authenticates transparently.
 
 ### Managing users
 
@@ -267,26 +290,30 @@ etcdctl --endpoints=localhost:3379 --user root:pass user get alice
 
 ### RBAC rule evaluation
 
-A request is permitted when the authenticated user has at least one role whose permissions cover the requested key and operation type:
+A request is permitted when the authenticated user has at least one role whose permissions cover the requested key and
+operation type:
 
-| Operation | Required permission |
-|---|---|
-| `Range` (Get / List) | `read` |
-| `Put` | `write` |
-| `DeleteRange` | `write` |
-| `Txn` | `write` |
-| `Watch` | `read` |
+| Operation            | Required permission |
+|----------------------|---------------------|
+| `Range` (Get / List) | `read`              |
+| `Put`                | `write`             |
+| `DeleteRange`        | `write`             |
+| `Txn`                | `write`             |
+| `Watch`              | `read`              |
 
 A permission entry covers a key when:
+
 - **Exact key** (`--prefix` omitted): the key matches exactly.
-- **Prefix range** (`--prefix`): the key starts with the permission's key prefix (computed as `rangeEnd = prefix[:-1] + chr(ord(prefix[-1])+1)`).
+- **Prefix range** (`--prefix`): the key starts with the permission's key prefix (computed as
+  `rangeEnd = prefix[:-1] + chr(ord(prefix[-1])+1)`).
 - **Open-ended range** (`rangeEnd = "\x00"`): all keys ≥ the permission key.
 
 The `root` role always passes all checks regardless of the key.
 
 ### Auth namespace protection
 
-Keys under the `\x00auth/` prefix are reserved for internal auth storage. Access to these keys via the KV service is blocked for all users, including `root`. Attempting to read or write them returns `PermissionDenied`.
+Keys under the `\x00auth/` prefix are reserved for internal auth storage. Access to these keys via the KV service is
+blocked for all users, including `root`. Attempting to read or write them returns `PermissionDenied`.
 
 ### Rate limiting
 
@@ -294,8 +321,10 @@ To protect against brute-force attacks, T4 enforces a per-username rate limit on
 
 - **5 consecutive failures** within a **5-minute window** triggers a **15-minute lockout** for that username.
 - Subsequent `Authenticate` calls during the lockout period return an error without checking the password.
-- The lockout state is in-memory only and resets on node restart (intentional: a restart is already a privileged operation).
-- All authentication outcomes are recorded in the `t4_auth_attempts_total` metric with a `result` label (`success`, `fail`, `locked`).
+- The lockout state is in-memory only and resets on node restart (intentional: a restart is already a privileged
+  operation).
+- All authentication outcomes are recorded in the `t4_auth_attempts_total` metric with a `result` label (`success`,
+  `fail`, `locked`).
 
 ### Disabling auth
 
@@ -303,7 +332,8 @@ To protect against brute-force attacks, T4 enforces a per-username rate limit on
 etcdctl --endpoints=localhost:3379 --user root:pass auth disable
 ```
 
-Or restart the node without `--auth-enabled`. Auth state (users, roles) is preserved in Pebble — re-enabling auth later restores the same configuration.
+Or restart the node without `--auth-enabled`. Auth state (users, roles) is preserved in Pebble — re-enabling auth later
+restores the same configuration.
 
 ### Full example: read-only service account
 
@@ -332,15 +362,16 @@ t4 run --metrics-addr 0.0.0.0:9090 ...
 
 ### Endpoints
 
-| Path | Description |
-|---|---|
-| `GET /metrics` | Prometheus metrics |
-| `GET /healthz` | 200 once the node has started |
-| `GET /readyz` | 200 when the node is ready to serve reads |
+| Path           | Description                               |
+|----------------|-------------------------------------------|
+| `GET /metrics` | Prometheus metrics                        |
+| `GET /healthz` | 200 once the node has started             |
+| `GET /readyz`  | 200 when the node is ready to serve reads |
 
 ### Inspecting S3 storage state
 
-`t4 status` reads directly from S3 (no running node required) and prints the current checkpoint, object counts, and any registered branch forks:
+`t4 status` reads directly from S3 (no running node required) and prints the current checkpoint, object counts, and any
+registered branch forks:
 
 ```bash
 t4 status \
@@ -368,7 +399,8 @@ Use this to confirm a node is checkpointing regularly and to estimate how much s
 
 ### Grafana dashboard
 
-A pre-built Grafana dashboard is available at `docs/grafana-dashboard.json` (also served as `/grafana-dashboard.json` from the documentation site).
+A pre-built Grafana dashboard is available at `docs/grafana-dashboard.json` (also served as `/grafana-dashboard.json`
+from the documentation site).
 
 To import it:
 
@@ -379,52 +411,54 @@ To import it:
 
 The dashboard contains six sections:
 
-| Section | Panels |
-|---|---|
-| **Cluster Health** | Leader count (split-brain indicator), current revision, node roles, max follower lag, elections/hr, resyncs/hr |
-| **Write Performance** | Throughput by op type, error rate, p50/p95/p99 write latency |
-| **Watch Performance** | Active watches/prefixes, p50/p95/p99 watch scan latency, revision span, scanned vs matched log entries |
-| **Replication** | Per-follower lag over time, forwarded write rate, forward round-trip latency |
-| **WAL & Checkpoints** | Upload rate, upload errors, upload duration, checkpoint frequency |
-| **Object Store (S3)** | Op rate by type, error rate, p50/p95/p99 latency |
+| Section               | Panels                                                                                                         |
+|-----------------------|----------------------------------------------------------------------------------------------------------------|
+| **Cluster Health**    | Leader count (split-brain indicator), current revision, node roles, max follower lag, elections/hr, resyncs/hr |
+| **Write Performance** | Throughput by op type, error rate, p50/p95/p99 write latency                                                   |
+| **Watch Performance** | Active watches/prefixes, p50/p95/p99 watch scan latency, revision span, scanned vs matched log entries         |
+| **Replication**       | Per-follower lag over time, forwarded write rate, forward round-trip latency                                   |
+| **WAL & Checkpoints** | Upload rate, upload errors, upload duration, checkpoint frequency                                              |
+| **Object Store (S3)** | Op rate by type, error rate, p50/p95/p99 latency                                                               |
 
 ### Prometheus metrics
 
-| Metric | Type | Labels | Description |
-|---|---|---|---|
-| `t4_writes_total` | counter | `op` | Completed write operations |
-| `t4_write_errors_total` | counter | `op` | Write operations that returned an error |
-| `t4_write_duration_seconds` | histogram | `op` | Write latency (WAL + apply) |
-| `t4_forwarded_writes_total` | counter | `op` | Writes forwarded from follower to leader |
-| `t4_forward_duration_seconds` | histogram | `op` | Forwarded write round-trip latency |
-| `t4_current_revision` | gauge | — | Latest applied revision |
-| `t4_compact_revision` | gauge | — | Compaction watermark |
-| `t4_role` | gauge | `role` | 1 for the active role (`leader`/`follower`/`single`) |
-| `t4_wal_uploads_total` | counter | — | WAL segments successfully uploaded |
-| `t4_wal_upload_errors_total` | counter | — | Failed WAL segment uploads |
-| `t4_wal_upload_duration_seconds` | histogram | — | WAL segment upload latency |
-| `t4_wal_gc_segments_total` | counter | — | WAL segments deleted from S3 after checkpointing |
-| `t4_checkpoints_total` | counter | — | Checkpoints written to S3 |
-| `t4_elections_total` | counter | `outcome` | Election attempts (`won`/`lost`) |
-| `t4_follower_resyncs_total` | counter | `reason` | Full resync events triggered on followers (`behind_leader_start` / `ring_buffer_miss` / `stream_gap`) |
-| `t4_follower_lag_revisions` | gauge | `follower_id` | Revisions the follower is behind the leader (0 = fully caught up); absent when no followers connected |
-| `t4_auth_attempts_total` | counter | `result` | Authentication attempts (`success` / `fail` / `locked`) |
-| `t4_watch_active` | gauge | — | Currently active watch subscriptions |
-| `t4_watch_active_prefixes` | gauge | — | Distinct prefixes with active watch subscriptions |
-| `t4_watch_scan_duration_seconds` | histogram | — | Time spent scanning revision logs for watch delivery |
-| `t4_watch_scan_revision_span` | histogram | — | Revision span covered by each watch scan |
-| `t4_watch_scan_entries_total` | counter | `result` | Watch scan entries by result (`scanned` / `matched`) |
+| Metric                           | Type      | Labels        | Description                                                                                           |
+|----------------------------------|-----------|---------------|-------------------------------------------------------------------------------------------------------|
+| `t4_writes_total`                | counter   | `op`          | Completed write operations                                                                            |
+| `t4_write_errors_total`          | counter   | `op`          | Write operations that returned an error                                                               |
+| `t4_write_duration_seconds`      | histogram | `op`          | Write latency (WAL + apply)                                                                           |
+| `t4_forwarded_writes_total`      | counter   | `op`          | Writes forwarded from follower to leader                                                              |
+| `t4_forward_duration_seconds`    | histogram | `op`          | Forwarded write round-trip latency                                                                    |
+| `t4_current_revision`            | gauge     | —             | Latest applied revision                                                                               |
+| `t4_compact_revision`            | gauge     | —             | Compaction watermark                                                                                  |
+| `t4_role`                        | gauge     | `role`        | 1 for the active role (`leader`/`follower`/`single`)                                                  |
+| `t4_wal_uploads_total`           | counter   | —             | WAL segments successfully uploaded                                                                    |
+| `t4_wal_upload_errors_total`     | counter   | —             | Failed WAL segment uploads                                                                            |
+| `t4_wal_upload_duration_seconds` | histogram | —             | WAL segment upload latency                                                                            |
+| `t4_wal_gc_segments_total`       | counter   | —             | WAL segments deleted from S3 after checkpointing                                                      |
+| `t4_checkpoints_total`           | counter   | —             | Checkpoints written to S3                                                                             |
+| `t4_elections_total`             | counter   | `outcome`     | Election attempts (`won`/`lost`)                                                                      |
+| `t4_follower_resyncs_total`      | counter   | `reason`      | Full resync events triggered on followers (`behind_leader_start` / `ring_buffer_miss` / `stream_gap`) |
+| `t4_follower_lag_revisions`      | gauge     | `follower_id` | Revisions the follower is behind the leader (0 = fully caught up); absent when no followers connected |
+| `t4_auth_attempts_total`         | counter   | `result`      | Authentication attempts (`success` / `fail` / `locked`)                                               |
+| `t4_watch_active`                | gauge     | —             | Currently active watch subscriptions                                                                  |
+| `t4_watch_active_prefixes`       | gauge     | —             | Distinct prefixes with active watch subscriptions                                                     |
+| `t4_watch_scan_duration_seconds` | histogram | —             | Time spent scanning revision logs for watch delivery                                                  |
+| `t4_watch_scan_revision_span`    | histogram | —             | Revision span covered by each watch scan                                                              |
+| `t4_watch_scan_entries_total`    | counter   | `result`      | Watch scan entries by result (`scanned` / `matched`)                                                  |
 
 `op` label values: `put`, `create`, `update`, `delete`, `compact`.
 
-The two object-store metrics cover all S3 operations (WAL upload, checkpoint write, manifest read, SST download, leader-lock conditional PUT, etc.):
+The two object-store metrics cover all S3 operations (WAL upload, checkpoint write, manifest read, SST download,
+leader-lock conditional PUT, etc.):
 
-| Metric | Type | Labels | Description |
-|---|---|---|---|
-| `t4_object_store_ops_total` | counter | `op`, `result` | S3 operations by type and outcome (`success`/`error`) |
-| `t4_object_store_duration_seconds` | histogram | `op` | S3 operation latency |
+| Metric                             | Type      | Labels         | Description                                           |
+|------------------------------------|-----------|----------------|-------------------------------------------------------|
+| `t4_object_store_ops_total`        | counter   | `op`, `result` | S3 operations by type and outcome (`success`/`error`) |
+| `t4_object_store_duration_seconds` | histogram | `op`           | S3 operation latency                                  |
 
-`op` label values for object store: `get`, `put`, `delete`, `delete_many`, `list`, `get_etag`, `put_if_absent`, `put_if_match`.
+`op` label values for object store: `get`, `put`, `delete`, `delete_many`, `list`, `get_etag`, `put_if_absent`,
+`put_if_match`.
 
 ### Alerting
 
@@ -548,41 +582,46 @@ groups:
 
 ## Performance
 
-Numbers are from `go test -bench=. -benchtime=10s` on an Apple M4 Pro (12 cores, NVMe SSD). All tests use in-process loopback — no real network or S3.
+Numbers are from `go test -bench=. -benchtime=10s` on an Apple M4 Pro (12 cores, NVMe SSD). All tests use in-process
+loopback — no real network or S3.
 
 ### Single-node (no peers, no S3)
 
-Write latency is dominated by a single WAL fsync (~4 ms on NVMe). Concurrent writers are automatically batched by the `commitLoop` into a single fsync per drain cycle (group commit).
+Write latency is dominated by a single WAL fsync (~4 ms on NVMe). Concurrent writers are automatically batched by the
+`commitLoop` into a single fsync per drain cycle (group commit).
 
-| Operation | Throughput | p50 | p95 | p99 |
-|---|---|---|---|---|
-| `Put` (serial) | ~231 writes/s | 4.1 ms | 6.3 ms | 8.0 ms |
-| `Put` (192 concurrent writers) | ~15,800 writes/s | — | — | — |
-| `Get` / `LinearizableGet` (leader) | ~2,260,000 reads/s | 0.44 µs | — | — |
-| `List` (100 keys) | ~28,000 ops/s | 35.7 µs | — | — |
-| Watch event delivery | — | 4.8 ms | 7.8 ms | 11.1 ms |
-| Watch fan-out (500 watchers) | ~186 writes/s | ~5.4 ms | — | — |
+| Operation                          | Throughput         | p50     | p95    | p99     |
+|------------------------------------|--------------------|---------|--------|---------|
+| `Put` (serial)                     | ~231 writes/s      | 4.1 ms  | 6.3 ms | 8.0 ms  |
+| `Put` (192 concurrent writers)     | ~15,800 writes/s   | —       | —      | —       |
+| `Get` / `LinearizableGet` (leader) | ~2,260,000 reads/s | 0.44 µs | —      | —       |
+| `List` (100 keys)                  | ~28,000 ops/s      | 35.7 µs | —      | —       |
+| Watch event delivery               | —                  | 4.8 ms  | 7.8 ms | 11.1 ms |
+| Watch fan-out (500 watchers)       | ~186 writes/s      | ~5.4 ms | —      | —       |
 
 ### 3-node cluster (localhost loopback)
 
-Write latency = leader WAL fsync + quorum ACK round-trip (follower WAL fsync + network). On loopback, both nodes share the same SSD so each write costs roughly two sequential fsyncs.
+Write latency = leader WAL fsync + quorum ACK round-trip (follower WAL fsync + network). On loopback, both nodes share
+the same SSD so each write costs roughly two sequential fsyncs.
 
-| Operation | Throughput | p50 | p95 | p99 |
-|---|---|---|---|---|
-| `Put` (serial) | ~70 writes/s | 11.1 ms | 17.0 ms | 21.0 ms |
-| `Put` (192 concurrent writers) | ~520 writes/s | — | — | — |
-| `LinearizableGet` (follower) | ~20,800 reads/s | 48 µs | — | — |
+| Operation                      | Throughput      | p50     | p95     | p99     |
+|--------------------------------|-----------------|---------|---------|---------|
+| `Put` (serial)                 | ~70 writes/s    | 11.1 ms | 17.0 ms | 21.0 ms |
+| `Put` (192 concurrent writers) | ~520 writes/s   | —       | —       | —       |
+| `LinearizableGet` (follower)   | ~20,800 reads/s | 48 µs   | —       | —       |
 
-With group commit, the per-write overhead of the quorum ACK round-trip disappears almost entirely under load — high concurrency improves throughput by batching many writes into one ACK round.
+With group commit, the per-write overhead of the quorum ACK round-trip disappears almost entirely under load — high
+concurrency improves throughput by batching many writes into one ACK round.
 
 ### Dataset size
 
-Write latency is dominated by WAL fsync and is independent of dataset size. Read latency grows as the working set exceeds the Pebble block cache (Pebble reads SST files from disk for cold data).
+Write latency is dominated by WAL fsync and is independent of dataset size. Read latency grows as the working set
+exceeds the Pebble block cache (Pebble reads SST files from disk for cold data).
 
-| Dataset | `Put` latency | `Get` latency | Notes |
-|---|---|---|---|
-| 10 K keys | ~5.5 ms | ~0.9 µs | all data in memtable / block cache |
-| 100 K keys | ~4.6 ms | ~8.9 µs | some SST reads from disk |
+| Dataset    | `Put` latency | `Get` latency | Notes                              |
+|------------|---------------|---------------|------------------------------------|
+| 10 K keys  | ~5.5 ms       | ~0.9 µs       | all data in memtable / block cache |
+| 100 K keys | ~4.6 ms       | ~8.9 µs       | some SST reads from disk           |
 
 Pebble itself handles datasets in the tens of GB on commodity NVMe. T4 adds no structural limit beyond Pebble's own.
 
@@ -590,17 +629,20 @@ Pebble itself handles datasets in the tens of GB on commodity NVMe. T4 adds no s
 
 Write latency scales with inter-node RTT and S3 latency (single-node only):
 
-| Scenario | Additional latency | Notes |
-|---|---|---|
-| Cluster, same-host loopback | +15 ms | loopback gRPC + follower fsync |
-| Cluster, LAN (1 ms RTT) | +9 ms | ≈ follower fsync + 2× 0.5 ms network |
-| Cluster, cross-AZ (5 ms RTT) | +18 ms | ≈ follower fsync + 2× 5 ms network |
-| Cluster, cross-region (50 ms RTT) | +108 ms | high-latency links hurt serial throughput most |
-| Single-node, S3 upload | +100–500 ms | sync upload per WAL segment — use cluster mode for low latency |
+| Scenario                          | Additional latency | Notes                                                          |
+|-----------------------------------|--------------------|----------------------------------------------------------------|
+| Cluster, same-host loopback       | +15 ms             | loopback gRPC + follower fsync                                 |
+| Cluster, LAN (1 ms RTT)           | +9 ms              | ≈ follower fsync + 2× 0.5 ms network                           |
+| Cluster, cross-AZ (5 ms RTT)      | +18 ms             | ≈ follower fsync + 2× 5 ms network                             |
+| Cluster, cross-region (50 ms RTT) | +108 ms            | high-latency links hurt serial throughput most                 |
+| Single-node, S3 upload            | +100–500 ms        | sync upload per WAL segment — use cluster mode for low latency |
 
-In cluster mode, **S3 uploads are async** (disaster-recovery only) and add zero latency to the write path. Single-node mode uploads each WAL segment to S3 synchronously; write latency is dominated by S3 round-trip, not local fsync. For low-latency single-node deployments without S3, latency is entirely local disk (~8 ms NVMe).
+In cluster mode, **S3 uploads are async** (disaster-recovery only) and add zero latency to the write path. Single-node
+mode uploads each WAL segment to S3 synchronously; write latency is dominated by S3 round-trip, not local fsync. For
+low-latency single-node deployments without S3, latency is entirely local disk (~8 ms NVMe).
 
-Read latency on a follower includes one `ForwardGetRevision` gRPC call to the leader to obtain the current revision, then a local Pebble lookup. On localhost this costs ~55 µs; on LAN expect ~1–2 ms; on cross-AZ ~10 ms.
+Read latency on a follower includes one `ForwardGetRevision` gRPC call to the leader to obtain the current revision,
+then a local Pebble lookup. On localhost this costs ~55 µs; on LAN expect ~1–2 ms; on cross-AZ ~10 ms.
 
 ---
 
@@ -609,10 +651,13 @@ Read latency on a follower includes one `ForwardGetRevision` gRPC call to the le
 ### What is durable
 
 A write is durable when it has been:
-- fsynced to the leader's WAL **and** ACKed by all connected followers (cluster mode) — the entry exists on at least two nodes' WALs before the caller sees success, **or**
+
+- fsynced to the leader's WAL **and** ACKed by all connected followers (cluster mode) — the entry exists on at least two
+  nodes' WALs before the caller sees success, **or**
 - fsynced to the local WAL **and** the WAL segment has been uploaded to S3 (single-node mode).
 
-In cluster mode S3 is disaster-recovery only (both nodes fail simultaneously). WAL uploads are fully async and do not affect write latency. In single-node mode without S3, durability depends entirely on local disk.
+In cluster mode S3 is disaster-recovery only (both nodes fail simultaneously). WAL uploads are fully async and do not
+affect write latency. In single-node mode without S3, durability depends entirely on local disk.
 
 ### Recovery procedure
 
@@ -631,30 +676,41 @@ Steps 4–5 ensure that no committed write is lost even if the node is killed be
 
 **Cluster mode**
 
-In cluster mode, S3 uploads are fully async — WAL segments and checkpoints are uploaded in the background without blocking writes. If S3 becomes unavailable:
+In cluster mode, S3 uploads are fully async — WAL segments and checkpoints are uploaded in the background without
+blocking writes. If S3 becomes unavailable:
 
 - **Writes continue.** Durability is backed by the peer WAL + quorum ACK across nodes, not by S3.
 - **WAL uploads queue.** Failed uploads are retried; a backlog of unsealed segments accumulates in `<data-dir>/wal/`.
-- **Leader election is unaffected** as long as the existing lock record is still readable from S3. If the lock expires or cannot be read, election is blocked until S3 is reachable again.
-- **No committed write is lost.** On restart, local WAL segments are replayed before any S3 reads (step 4 of the recovery procedure). Data that was fsynced to local disk is safe regardless of S3 state.
+- **Leader election is unaffected** as long as the existing lock record is still readable from S3. If the lock expires
+  or cannot be read, election is blocked until S3 is reachable again.
+- **No committed write is lost.** On restart, local WAL segments are replayed before any S3 reads (step 4 of the
+  recovery procedure). Data that was fsynced to local disk is safe regardless of S3 state.
 
 **Single-node mode**
 
-In single-node mode, each WAL segment is uploaded to S3 synchronously before the write is acknowledged. If S3 becomes unavailable:
+In single-node mode, each WAL segment is uploaded to S3 synchronously before the write is acknowledged. If S3 becomes
+unavailable:
 
-- **Writes fail** once the in-progress WAL segment fills and a rotation is attempted. The node fences itself to prevent unacknowledged data from accumulating silently.
-- **Already-acknowledged writes are safe.** All segments uploaded before the outage are on S3; the current open segment is on local disk.
-- **To recover:** repair S3 access and restart the node. On startup it replays all local WAL segments (including any partial segment left on disk), then resumes normal operation.
+- **Writes fail** once the in-progress WAL segment fills and a rotation is attempted. The node fences itself to prevent
+  unacknowledged data from accumulating silently.
+- **Already-acknowledged writes are safe.** All segments uploaded before the outage are on S3; the current open segment
+  is on local disk.
+- **To recover:** repair S3 access and restart the node. On startup it replays all local WAL segments (including any
+  partial segment left on disk), then resumes normal operation.
 
 **After any S3 outage — what is safe**
 
-On startup, T4 replays local WAL segments (step 4) before reading from S3, so no write that was fsynced to local disk is lost even if the segment was never uploaded. In cluster mode with multiple survivors, any write that completed quorum ACK across nodes is never lost even if all S3 state is gone.
+On startup, T4 replays local WAL segments (step 4) before reading from S3, so no write that was fsynced to local disk is
+lost even if the segment was never uploaded. In cluster mode with multiple survivors, any write that completed quorum
+ACK across nodes is never lost even if all S3 state is gone.
 
 ---
 
 ### Network partitions (cluster mode)
 
-T4 uses S3 as the split-brain arbiter. The leader continuously refreshes a `LastSeenNano` timestamp in the S3 leader lock every `FollowerRetryInterval` (2 s) while followers are disconnected. A follower only promotes itself if it cannot reach the leader **and** the lock is older than `LeaderLivenessTTL` (6 s).
+T4 uses S3 as the split-brain arbiter. The leader continuously refreshes a `LastSeenNano` timestamp in the S3 leader
+lock every `FollowerRetryInterval` (2 s) while followers are disconnected. A follower only promotes itself if it cannot
+reach the leader **and** the lock is older than `LeaderLivenessTTL` (6 s).
 
 **Follower partitioned from leader, leader can still reach S3:**
 
@@ -669,20 +725,26 @@ T4 uses S3 as the split-brain arbiter. The leader continuously refreshes a `Last
 
 1. Leader can no longer touch `LastSeenNano`.
 2. After `LeaderLivenessTTL` (6 s) the lock goes stale.
-3. A follower that has been retrying attempts a conditional PUT (`If-Match: <etag>`) on the lock — only one candidate wins this atomic race.
+3. A follower that has been retrying attempts a conditional PUT (`If-Match: <etag>`) on the lock — only one candidate
+   wins this atomic race.
 4. New leader begins streaming WAL entries.
 5. Former leader detects the superseded lock on its next fenced check and steps down.
 6. Any write that completed quorum ACK before the partition exists on at least two nodes' WALs and is **never lost**.
 
 **Writes during a follower partition:**
 
-While followers are disconnected, the leader's `WaitForFollowers` returns immediately (0 connected followers → 0 ACKs required). Writes proceed but are acknowledged only by the leader node. WAL segments continue to be uploaded to S3 asynchronously. If the leader fails while the partition persists and before the segments reach S3, those post-partition writes may be lost. For the highest write durability during a known partition, avoid acknowledging client writes until the partition heals, or use a 3-node cluster so quorum (2 of 3) can still be reached with one node partitioned.
+While followers are disconnected, the leader's `WaitForFollowers` returns immediately (0 connected followers → 0 ACKs
+required). Writes proceed but are acknowledged only by the leader node. WAL segments continue to be uploaded to S3
+asynchronously. If the leader fails while the partition persists and before the segments reach S3, those post-partition
+writes may be lost. For the highest write durability during a known partition, avoid acknowledging client writes until
+the partition heals, or use a 3-node cluster so quorum (2 of 3) can still be reached with one node partitioned.
 
 ---
 
 ## Restore from checkpoint
 
-`t4 restore` lets you inspect available checkpoints and download one to a local data directory so that `t4 run` can boot from it.
+`t4 restore` lets you inspect available checkpoints and download one to a local data directory so that `t4 run` can boot
+from it.
 
 ### Listing checkpoints
 
@@ -750,7 +812,9 @@ t4 run \
   --listen    0.0.0.0:3379
 ```
 
-> **Note:** If you point `--s3-bucket/prefix` at the **original** cluster's prefix, the node will replay all WAL segments written after the restored checkpoint and arrive at the current state — this is recovery, not a rollback. To stay at the past revision, omit `--s3-bucket` or use a different prefix.
+> **Note:** If you point `--s3-bucket/prefix` at the **original** cluster's prefix, the node will replay all WAL
+> segments written after the restored checkpoint and arrive at the current state — this is recovery, not a rollback. To
+> stay at the past revision, omit `--s3-bucket` or use a different prefix.
 
 ### Point-in-time recovery workflow
 
@@ -781,9 +845,40 @@ For zero-copy forking (no SST downloads) use `t4 branch fork` instead — see [B
 
 ## Storage management
 
+### Local database size
+
+As a sizing reference, a local Pebble database with 1,000,000 live keys and 256-byte varied values measured about **317
+MiB on disk after compaction** (roughly **332 bytes per key**). This includes T4's live key index and revision log
+entries. The test used keys like `/size/000000001`, so longer keys add directly to the total.
+
+For the same 256-byte value size:
+
+|   Live keys | Local DB size | Basis        |
+|------------:|--------------:|--------------|
+|   1 million |      ~317 MiB | measured     |
+|  10 million |      ~3.0 GiB | measured     |
+| 100 million |       ~30 GiB | extrapolated |
+|   1 billion |      ~300 GiB | extrapolated |
+
+For 1,000,000 live keys:
+
+| Value size | Local DB size | Bytes per key |
+|-----------:|--------------:|--------------:|
+|       64 B |       ~95 MiB |        ~100 B |
+|      128 B |      ~159 MiB |        ~167 B |
+|      256 B |      ~317 MiB |        ~332 B |
+|      1 KiB |     ~1.04 GiB |      ~1,118 B |
+|      4 KiB |      ~4.0 GiB |      ~4,279 B |
+
+Actual size varies with key length, value compressibility, update/delete history, and Pebble compaction state. S3 stores
+the same logical database as checkpoint SSTs plus retained WAL segments; a single latest checkpoint is usually in the
+same range as the compacted local DB, while total S3 usage depends on checkpoint retention, WAL retention, and
+branch-pinned SSTs.
+
 ### Garbage collection
 
-Old checkpoints and WAL segments accumulate in S3 unless explicitly pruned. Run `t4 gc` periodically (e.g. daily via cron) to reclaim storage:
+Old checkpoints and WAL segments accumulate in S3 unless explicitly pruned. Run `t4 gc` periodically (e.g. daily via
+cron) to reclaim storage:
 
 ```bash
 t4 gc \
@@ -792,10 +887,12 @@ t4 gc \
   --keep 3
 ```
 
-`--keep` (default: 3) sets how many of the most recent checkpoints to retain. The command performs three passes in order:
+`--keep` (default: 3) sets how many of the most recent checkpoints to retain. The command performs three passes in
+order:
 
 1. **Checkpoint GC** — deletes old checkpoint archives beyond the `--keep` window.
-2. **Orphan SST GC** — deletes SST files that were exclusively referenced by the deleted checkpoints and are no longer reachable from any surviving checkpoint or live branch.
+2. **Orphan SST GC** — deletes SST files that were exclusively referenced by the deleted checkpoints and are no longer
+   reachable from any surviving checkpoint or live branch.
 3. **WAL segment GC** — deletes WAL segments whose entire revision range is covered by the latest surviving checkpoint.
 
 Output:
@@ -809,20 +906,25 @@ GC complete
 
 #### Branch safety
 
-Before deleting any checkpoint, `t4 gc` reads all active branch registrations from the `branches/` prefix of the source store. Any checkpoint pinned by an active branch is skipped unconditionally — even if it falls outside the `--keep` window. The SSTs it references are also excluded from orphan deletion.
+Before deleting any checkpoint, `t4 gc` reads all active branch registrations from the `branches/` prefix of the source
+store. Any checkpoint pinned by an active branch is skipped unconditionally — even if it falls outside the `--keep`
+window. The SSTs it references are also excluded from orphan deletion.
 
 The invariant to maintain:
-- Call `t4 branch fork` **before** running GC on the source — this writes the registry entry that protects the checkpoint.
-- Call `t4 branch unfork` only after the branch node is fully decommissioned — after this, GC is free to reclaim the checkpoint and its SSTs.
+
+- Call `t4 branch fork` **before** running GC on the source — this writes the registry entry that protects the
+  checkpoint.
+- Call `t4 branch unfork` only after the branch node is fully decommissioned — after this, GC is free to reclaim the
+  checkpoint and its SSTs.
 
 #### Suggested retention policy
 
-| Scenario | `--keep` |
-|---|---|
-| Development / CI | 1–2 |
-| Single-node production | 3–5 |
-| Multi-node cluster | 5–10 |
-| Long-lived branches | keep ≥ number of active branches + 3 |
+| Scenario               | `--keep`                             |
+|------------------------|--------------------------------------|
+| Development / CI       | 1–2                                  |
+| Single-node production | 3–5                                  |
+| Multi-node cluster     | 5–10                                 |
+| Long-lived branches    | keep ≥ number of active branches + 3 |
 
 Use `t4 status` to check current checkpoint and WAL segment counts before and after running GC.
 
@@ -832,17 +934,25 @@ Use `t4 status` to check current checkpoint and WAL segment counts before and af
 
 ### WAL format versioning
 
-Each WAL segment file begins with a 4-byte magic header `"T4\x01\n"`. The third byte (`\x01`) is the **WAL format version** (currently 1). Readers verify the full magic string on open; a format change bumps this byte, causing old readers to reject new segments with a clear error rather than silently misinterpreting them.
+Each WAL segment file begins with a 4-byte magic header `"T4\x01\n"`. The third byte (`\x01`) is the **WAL format
+version** (currently 1). Readers verify the full magic string on open; a format change bumps this byte, causing old
+readers to reject new segments with a clear error rather than silently misinterpreting them.
 
-**Current: WAL format version 1.** Entry wire format: CRC32C-framed records with big-endian fixed-width fields (see `internal/wal/entry.go`).
+**Current: WAL format version 1.** Entry wire format: CRC32C-framed records with big-endian fixed-width fields (see
+`internal/wal/entry.go`).
 
 ### Checkpoint format versioning
 
-Checkpoint manifests and index files are JSON. Both include a `format_version` field (integer, omitempty). The current version is **1**. Older nodes that do not know this field treat it as version 0 (the original format) — identical to version 1.
+Checkpoint manifests and index files are JSON. Both include a `format_version` field (integer, omitempty). The current
+version is **1**. Older nodes that do not know this field treat it as version 0 (the original format) — identical to
+version 1.
 
-When a node reads a manifest or index with `format_version` higher than it knows, it logs a warning and continues. A future incompatible change will increment `format_version` and require the old nodes to be upgraded before they can read new checkpoints.
+When a node reads a manifest or index with `format_version` higher than it knows, it logs a warning and continues. A
+future incompatible change will increment `format_version` and require the old nodes to be upgraded before they can read
+new checkpoints.
 
-**Compatibility rule:** adding new JSON fields with `omitempty` is always backward-compatible. Only structural changes that alter how existing fields are interpreted require a version bump.
+**Compatibility rule:** adding new JSON fields with `omitempty` is always backward-compatible. Only structural changes
+that alter how existing fields are interpreted require a version bump.
 
 ### Rolling upgrade
 
@@ -878,7 +988,8 @@ kill -TERM <pid-B>
 kill -TERM <pid-C>
 ```
 
-After the last old node is stopped, all writes go through the new binary and all new checkpoints carry `format_version=1`.
+After the last old node is stopped, all writes go through the new binary and all new checkpoints carry
+`format_version=1`.
 
 ### Downgrade path
 
@@ -890,13 +1001,15 @@ A downgrade is safe as long as no checkpoint with `format_version > 1` has been 
 t4 restore list --s3-bucket my-bucket --s3-prefix t4/
 ```
 
-If a new format version was introduced (e.g., format_version=2), downgrade to the old binary requires restoring from the last format_version=1 checkpoint instead of the latest one.
+If a new format version was introduced (e.g., format_version=2), downgrade to the old binary requires restoring from the
+last format_version=1 checkpoint instead of the latest one.
 
 ---
 
 ## Branching
 
-Branches let you fork a database at any checkpoint with zero S3 data copies. SST files are content-addressed and shared between the source and all branches — no data is duplicated.
+Branches let you fork a database at any checkpoint with zero S3 data copies. SST files are content-addressed and shared
+between the source and all branches — no data is duplicated.
 
 ### Requirements
 
@@ -925,7 +1038,8 @@ t4 run \
   --branch-checkpoint checkpoint/0000000001/00000000000000000100/manifest.json
 ```
 
-On first boot the branch node downloads SSTs and Pebble metadata from the source prefix. On subsequent restarts `--branch-checkpoint` is ignored (the local data directory already exists).
+On first boot the branch node downloads SSTs and Pebble metadata from the source prefix. On subsequent restarts
+`--branch-checkpoint` is ignored (the local data directory already exists).
 
 ### Creating a branch (Go library)
 
@@ -939,24 +1053,25 @@ branchStore := object.NewS3Store(object.S3Config{Bucket: "my-bucket", Prefix: "t
 // Register and get the checkpoint key.
 cpKey, err := t4.Fork(ctx, sourceStore, "my-branch")
 if err != nil {
-    log.Fatal(err)
+log.Fatal(err)
 }
 
 // Start the branch node.
 node, err := t4.Open(t4.Config{
-    DataDir:       "/var/lib/t4-branch",
-    ObjectStore:   branchStore,
-    AncestorStore: sourceStore,
-    BranchPoint: &t4.BranchPoint{
-        SourceStore:   sourceStore,
-        CheckpointKey: cpKey,
-    },
+DataDir:       "/var/lib/t4-branch",
+ObjectStore:   branchStore,
+AncestorStore: sourceStore,
+BranchPoint: &t4.BranchPoint{
+SourceStore:   sourceStore,
+CheckpointKey: cpKey,
+},
 })
 ```
 
 ### Forking from a specific checkpoint
 
-By default `Fork` uses the latest checkpoint. To fork from an earlier revision, call `checkpoint.RegisterBranch` directly with the specific key:
+By default `Fork` uses the latest checkpoint. To fork from an earlier revision, call `checkpoint.RegisterBranch`
+directly with the specific key:
 
 ```bash
 # CLI
@@ -972,7 +1087,7 @@ import "github.com/t4db/t4/internal/checkpoint"
 
 cpKey := "checkpoint/0000000001/00000000000000000050/manifest.json"
 if err := checkpoint.RegisterBranch(ctx, sourceStore, "my-branch", cpKey); err != nil {
-    log.Fatal(err)
+log.Fatal(err)
 }
 
 ### Removing a branch
@@ -988,7 +1103,7 @@ t4 branch unfork \
 
 ```go
 if err := t4.Unfork(ctx, sourceStore, "my-branch"); err != nil {
-    log.Fatal(err)
+log.Fatal(err)
 }
 ```
 
@@ -1006,9 +1121,11 @@ if err := t4.Unfork(ctx, sourceStore, "my-branch"); err != nil {
 
 ## Point-in-time restore (S3 versioning)
 
-> **Note**: this mechanism requires S3 versioning to be enabled on the bucket. For most use cases, [Branching](#branching) is simpler and does not require versioning.
+> **Note**: this mechanism requires S3 versioning to be enabled on the bucket. For most use
+> cases, [Branching](#branching) is simpler and does not require versioning.
 
-`RestorePoint` bootstraps a new node from a specific set of S3 object version IDs captured at a past moment. See [api.md — Point-in-time restore](api.md#point-in-time-restore-s3-versioning) for the Go API.
+`RestorePoint` bootstraps a new node from a specific set of S3 object version IDs captured at a past moment.
+See [api.md — Point-in-time restore](api.md#point-in-time-restore-s3-versioning) for the Go API.
 
 ### Requirements
 

--- a/internal/store/db_size_test.go
+++ b/internal/store/db_size_test.go
@@ -1,0 +1,158 @@
+package store
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/t4db/t4/internal/wal"
+)
+
+type dbSizeTestLogger struct{}
+
+func (dbSizeTestLogger) Warnf(string, ...interface{}) {}
+
+func TestDBSizeMillionKeys(t *testing.T) {
+	if os.Getenv("T4_DB_SIZE_TEST") != "1" {
+		t.Skip("set T4_DB_SIZE_TEST=1 to run the 1M-key DB size test")
+	}
+
+	keys := envInt(t, "T4_DB_SIZE_KEYS", 1_000_000)
+	valueBytes := envInt(t, "T4_DB_SIZE_VALUE_BYTES", 256)
+	batchSize := envInt(t, "T4_DB_SIZE_BATCH", 10_000)
+
+	dir := filepath.Join(t.TempDir(), "db")
+	s, err := Open(dir, dbSizeTestLogger{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	start := time.Now()
+	for base := 0; base < keys; base += batchSize {
+		n := batchSize
+		if remaining := keys - base; remaining < n {
+			n = remaining
+		}
+		entries := make([]wal.Entry, n)
+		for i := 0; i < n; i++ {
+			rev := int64(base + i + 1)
+			key := fmt.Sprintf("/size/%09d", base+i)
+			entries[i] = wal.Entry{
+				Revision:       rev,
+				Term:           1,
+				Op:             wal.OpCreate,
+				Key:            key,
+				Value:          testValue(base+i, valueBytes),
+				CreateRevision: rev,
+			}
+		}
+		if err := s.Apply(entries); err != nil {
+			t.Fatalf("Apply batch starting at key %d: %v", base, err)
+		}
+	}
+	writeElapsed := time.Since(start)
+
+	if got, err := s.Count("/size/"); err != nil {
+		t.Fatalf("Count: %v", err)
+	} else if got != int64(keys) {
+		t.Fatalf("Count: want %d got %d", keys, got)
+	}
+	if err := s.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	flushedSize, err := dirSize(dir)
+	if err != nil {
+		t.Fatalf("dirSize after flush: %v", err)
+	}
+
+	compactStart := time.Now()
+	if err := s.Pebble().Compact([]byte{}, []byte{0xff}, true); err != nil {
+		t.Fatalf("Pebble compact: %v", err)
+	}
+	compactElapsed := time.Since(compactStart)
+	compactedSize, err := dirSize(dir)
+	if err != nil {
+		t.Fatalf("dirSize after compact: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	closedSize, err := dirSize(dir)
+	if err != nil {
+		t.Fatalf("dirSize after close: %v", err)
+	}
+
+	t.Logf("keys=%d value_bytes=%d batch=%d", keys, valueBytes, batchSize)
+	t.Logf("write_elapsed=%s write_rate=%.0f keys/s", writeElapsed, float64(keys)/writeElapsed.Seconds())
+	t.Logf("flushed_size=%s (%d bytes)", humanBytes(flushedSize), flushedSize)
+	t.Logf("pebble_compact_elapsed=%s compacted_size=%s (%d bytes)", compactElapsed, humanBytes(compactedSize), compactedSize)
+	t.Logf("closed_size=%s (%d bytes)", humanBytes(closedSize), closedSize)
+	t.Logf("closed_bytes_per_key=%.1f", float64(closedSize)/float64(keys))
+}
+
+func envInt(t *testing.T, name string, fallback int) int {
+	t.Helper()
+	raw := os.Getenv(name)
+	if raw == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		t.Fatalf("%s must be a positive integer, got %q", name, raw)
+	}
+	return n
+}
+
+func testValue(i, n int) []byte {
+	v := make([]byte, n)
+	x := uint64(i) + 0x9e3779b97f4a7c15
+	for j := range v {
+		x ^= x << 13
+		x ^= x >> 7
+		x ^= x << 17
+		v[j] = byte(x)
+	}
+	return v
+}
+
+func dirSize(root string) (int64, error) {
+	var total int64
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		total += info.Size()
+		return nil
+	})
+	return total, err
+}
+
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/website/src/content/docs/operations.md
+++ b/website/src/content/docs/operations.md
@@ -7,7 +7,8 @@ description: Deploy T4 in production — multi-node clusters, TLS, auth, observa
 
 ## Single-node with S3
 
-The simplest durable deployment. A single node writes WAL segments and checkpoints to S3. If the node is replaced or its disk is lost, it recovers automatically on the next start.
+The simplest durable deployment. A single node writes WAL segments and checkpoints to S3. If the node is replaced or its
+disk is lost, it recovers automatically on the next start.
 
 ```bash
 t4 run \
@@ -17,7 +18,8 @@ t4 run \
   --s3-prefix t4/
 ```
 
-AWS credentials are resolved from the standard chain: `AWS_*` environment variables, `~/.aws/credentials`, instance profile (EC2/ECS), workload identity (EKS).
+AWS credentials are resolved from the standard chain: `AWS_*` environment variables, `~/.aws/credentials`, instance
+profile (EC2/ECS), workload identity (EKS).
 
 ### MinIO or other S3-compatible stores
 
@@ -39,7 +41,8 @@ Multi-node mode requires:
 1. A shared S3 bucket (leader election lock + WAL archive).
 2. Each node has a unique `--node-id` and a `--peer-listen` address reachable by all other nodes.
 
-All nodes run the same command. At startup they race to acquire the S3 leader lock; the winner becomes the leader, the rest become followers.
+All nodes run the same command. At startup they race to acquire the S3 leader lock; the winner becomes the leader, the
+rest become followers.
 
 ### Three-node example
 
@@ -69,13 +72,26 @@ t4 run \
 
 ### Leader election and failover
 
-- On startup each node reads the S3 lock. If absent, it issues an **atomic conditional PUT** (`If-None-Match: *`); only one concurrent writer wins. The winner becomes the leader and records `LastSeenNano = now()` in the lock so followers see it as immediately alive.
-- The leader streams WAL entries to all followers over the peer port (default 3380). Followers apply entries and serve local reads.
-- A follower that observes `--follower-max-retries` consecutive stream failures (~10 s at default 5 × 2 s) checks the lock's `LastSeenNano`. If stale (older than `LeaderLivenessTTL` = 6 s), it attempts a takeover using `If-Match: <etag>` — only the candidate that read the same ETag wins the race. The new leader records its own address and `LastSeenNano`.
-- The former leader periodically re-reads the S3 lock (`--leader-watch-interval-sec`, default 300 s) and on every follower disconnect. Each check reads the lock **with its ETag**, then — if still the owner — writes a liveness touch using `If-Match: <etag>`. If the conditional touch is rejected (`ErrPreconditionFailed`), a new leader has taken over between the Read and the Touch: the old leader steps down immediately. This closes the Read→Touch split-brain race without a second round-trip.
+- On startup each node reads the S3 lock. If absent, it issues an **atomic conditional PUT** (`If-None-Match: *`); only
+  one concurrent writer wins. The winner becomes the leader and records `LastSeenNano = now()` in the lock so followers
+  see it as immediately alive.
+- The leader streams WAL entries to all followers over the peer port (default 3380). Followers apply entries and serve
+  local reads.
+- A follower that observes `--follower-max-retries` consecutive stream failures (~10 s at default 5 × 2 s) checks the
+  lock's `LastSeenNano`. If stale (older than `LeaderLivenessTTL` = 6 s), it attempts a takeover using
+  `If-Match: <etag>` — only the candidate that read the same ETag wins the race. The new leader records its own address
+  and `LastSeenNano`.
+- The former leader periodically re-reads the S3 lock (`--leader-watch-interval-sec`, default 300 s) and on every
+  follower disconnect. Each check reads the lock **with its ETag**, then — if still the owner — writes a liveness touch
+  using `If-Match: <etag>`. If the conditional touch is rejected (`ErrPreconditionFailed`), a new leader has taken over
+  between the Read and the Touch: the old leader steps down immediately. This closes the Read→Touch split-brain race
+  without a second round-trip.
 - Writes sent to a follower are automatically forwarded to the current leader and the result is returned to the caller.
 
-Leader election uses atomic conditional PUT (`If-None-Match`/`If-Match` on the `leader-lock` object). There is no TTL polling — the only S3 election writes are at startup, on leader takeover, and during liveness touches while followers are disconnected. In cluster mode, writes additionally require quorum ACK from all connected followers before returning to the caller.
+Leader election uses atomic conditional PUT (`If-None-Match`/`If-Match` on the `leader-lock` object). There is no TTL
+polling — the only S3 election writes are at startup, on leader takeover, and during liveness touches while followers
+are disconnected. In cluster mode, writes additionally require quorum ACK from all connected followers before returning
+to the caller.
 
 ### Adding a node to a running cluster
 
@@ -90,7 +106,8 @@ No manual registration or cluster membership changes are required.
 
 ### Scaling down
 
-Close the nodes you want to remove. The remaining nodes continue without any configuration change. If the leader is among the removed nodes, a follower will take over.
+Close the nodes you want to remove. The remaining nodes continue without any configuration change. If the leader is
+among the removed nodes, a follower will take over.
 
 ---
 
@@ -106,7 +123,8 @@ t4 run \
   --peer-tls-key  /etc/t4/tls/node.key
 ```
 
-Both the leader's gRPC server and the follower's gRPC client use these files. The same CA must be used on all nodes. TLS 1.3 is required; mutual authentication is enforced.
+Both the leader's gRPC server and the follower's gRPC client use these files. The same CA must be used on all nodes. TLS
+1.3 is required; mutual authentication is enforced.
 
 ### Embedded library
 
@@ -116,9 +134,9 @@ Pass `credentials.TransportCredentials` directly:
 serverCreds, clientCreds, err := buildTLS(caFile, certFile, keyFile)
 
 node, err := t4.Open(t4.Config{
-    ...
-    PeerServerTLS: serverCreds,
-    PeerClientTLS: clientCreds,
+...
+PeerServerTLS: serverCreds,
+PeerClientTLS: clientCreds,
 })
 ```
 
@@ -137,7 +155,8 @@ t4 run \
   --client-tls-key  /etc/t4/tls/server.key
 ```
 
-Clients connect with TLS but are not required to present a certificate. Use this when clients are etcd-compatible tools or libraries that support TLS but not mTLS.
+Clients connect with TLS but are not required to present a certificate. Use this when clients are etcd-compatible tools
+or libraries that support TLS but not mTLS.
 
 ```bash
 etcdctl --endpoints=https://localhost:3379 \
@@ -171,7 +190,10 @@ Client TLS and peer mTLS are independent — each uses its own cert/key/CA and c
 
 ## Authentication and RBAC
 
-T4 implements the etcd v3 Auth API: username/password authentication with bearer tokens, and role-based access control scoped to key prefixes. Auth state (users, roles, enabled flag) is stored in Pebble and flows through the WAL, so it is replicated to followers and included in S3 checkpoints. Bearer tokens are persisted to Pebble and survive node restarts — clients do not need to re-authenticate after a restart.
+T4 implements the etcd v3 Auth API: username/password authentication with bearer tokens, and role-based access control
+scoped to key prefixes. Auth state (users, roles, enabled flag) is stored in Pebble and flows through the WAL, so it is
+replicated to followers and included in S3 checkpoints. Bearer tokens are persisted to Pebble and survive node
+restarts — clients do not need to re-authenticate after a restart.
 
 Enable auth with `--auth-enabled`:
 
@@ -193,7 +215,8 @@ ETCDCTL_API=3 etcdctl --endpoints=localhost:3379 user add root
 ETCDCTL_API=3 etcdctl --endpoints=localhost:3379 auth enable
 ```
 
-Once enabled, all KV and Watch requests require a valid bearer token. The `root` user has unconditional access to all keys via the built-in `root` role.
+Once enabled, all KV and Watch requests require a valid bearer token. The `root` user has unconditional access to all
+keys via the built-in `root` role.
 
 > **Note:** The `root` user and `root` role cannot be deleted while auth is enabled.
 
@@ -205,7 +228,8 @@ ETCDCTL_API=3 etcdctl --endpoints=localhost:3379 \
   put /hello world
 ```
 
-The etcd client library handles token acquisition and refresh automatically when `--user` is provided. Tokens expire after `--token-ttl` seconds; the client re-authenticates transparently.
+The etcd client library handles token acquisition and refresh automatically when `--user` is provided. Tokens expire
+after `--token-ttl` seconds; the client re-authenticates transparently.
 
 ### Managing users
 
@@ -272,26 +296,30 @@ etcdctl --endpoints=localhost:3379 --user root:pass user get alice
 
 ### RBAC rule evaluation
 
-A request is permitted when the authenticated user has at least one role whose permissions cover the requested key and operation type:
+A request is permitted when the authenticated user has at least one role whose permissions cover the requested key and
+operation type:
 
-| Operation | Required permission |
-|---|---|
-| `Range` (Get / List) | `read` |
-| `Put` | `write` |
-| `DeleteRange` | `write` |
-| `Txn` | `write` |
-| `Watch` | `read` |
+| Operation            | Required permission |
+|----------------------|---------------------|
+| `Range` (Get / List) | `read`              |
+| `Put`                | `write`             |
+| `DeleteRange`        | `write`             |
+| `Txn`                | `write`             |
+| `Watch`              | `read`              |
 
 A permission entry covers a key when:
+
 - **Exact key** (`--prefix` omitted): the key matches exactly.
-- **Prefix range** (`--prefix`): the key starts with the permission's key prefix (computed as `rangeEnd = prefix[:-1] + chr(ord(prefix[-1])+1)`).
+- **Prefix range** (`--prefix`): the key starts with the permission's key prefix (computed as
+  `rangeEnd = prefix[:-1] + chr(ord(prefix[-1])+1)`).
 - **Open-ended range** (`rangeEnd = "\x00"`): all keys ≥ the permission key.
 
 The `root` role always passes all checks regardless of the key.
 
 ### Auth namespace protection
 
-Keys under the `\x00auth/` prefix are reserved for internal auth storage. Access to these keys via the KV service is blocked for all users, including `root`. Attempting to read or write them returns `PermissionDenied`.
+Keys under the `\x00auth/` prefix are reserved for internal auth storage. Access to these keys via the KV service is
+blocked for all users, including `root`. Attempting to read or write them returns `PermissionDenied`.
 
 ### Rate limiting
 
@@ -299,8 +327,10 @@ To protect against brute-force attacks, T4 enforces a per-username rate limit on
 
 - **5 consecutive failures** within a **5-minute window** triggers a **15-minute lockout** for that username.
 - Subsequent `Authenticate` calls during the lockout period return an error without checking the password.
-- The lockout state is in-memory only and resets on node restart (intentional: a restart is already a privileged operation).
-- All authentication outcomes are recorded in the `t4_auth_attempts_total` metric with a `result` label (`success`, `fail`, `locked`).
+- The lockout state is in-memory only and resets on node restart (intentional: a restart is already a privileged
+  operation).
+- All authentication outcomes are recorded in the `t4_auth_attempts_total` metric with a `result` label (`success`,
+  `fail`, `locked`).
 
 ### Disabling auth
 
@@ -308,7 +338,8 @@ To protect against brute-force attacks, T4 enforces a per-username rate limit on
 etcdctl --endpoints=localhost:3379 --user root:pass auth disable
 ```
 
-Or restart the node without `--auth-enabled`. Auth state (users, roles) is preserved in Pebble — re-enabling auth later restores the same configuration.
+Or restart the node without `--auth-enabled`. Auth state (users, roles) is preserved in Pebble — re-enabling auth later
+restores the same configuration.
 
 ### Full example: read-only service account
 
@@ -337,15 +368,16 @@ t4 run --metrics-addr 0.0.0.0:9090 ...
 
 ### Endpoints
 
-| Path | Description |
-|---|---|
-| `GET /metrics` | Prometheus metrics |
-| `GET /healthz` | 200 once the node has started |
-| `GET /readyz` | 200 when the node is ready to serve reads |
+| Path           | Description                               |
+|----------------|-------------------------------------------|
+| `GET /metrics` | Prometheus metrics                        |
+| `GET /healthz` | 200 once the node has started             |
+| `GET /readyz`  | 200 when the node is ready to serve reads |
 
 ### Inspecting S3 storage state
 
-`t4 status` reads directly from S3 (no running node required) and prints the current checkpoint, object counts, and any registered branch forks:
+`t4 status` reads directly from S3 (no running node required) and prints the current checkpoint, object counts, and any
+registered branch forks:
 
 ```bash
 t4 status \
@@ -384,40 +416,40 @@ To import it:
 
 The dashboard contains six sections:
 
-| Section | Panels |
-|---|---|
-| **Cluster Health** | Leader count (split-brain indicator), current revision, node roles, max follower lag, elections/hr, resyncs/hr |
-| **Write Performance** | Throughput by op type, error rate, p50/p95/p99 write latency |
-| **Watch Performance** | Active watches/prefixes, p50/p95/p99 watch scan latency, revision span, scanned vs matched log entries |
-| **Replication** | Per-follower lag over time, forwarded write rate, forward round-trip latency |
-| **WAL & Checkpoints** | Upload rate, upload errors, upload duration, checkpoint frequency |
-| **Object Store (S3)** | Op rate by type, error rate, p50/p95/p99 latency |
+| Section               | Panels                                                                                                         |
+|-----------------------|----------------------------------------------------------------------------------------------------------------|
+| **Cluster Health**    | Leader count (split-brain indicator), current revision, node roles, max follower lag, elections/hr, resyncs/hr |
+| **Write Performance** | Throughput by op type, error rate, p50/p95/p99 write latency                                                   |
+| **Watch Performance** | Active watches/prefixes, p50/p95/p99 watch scan latency, revision span, scanned vs matched log entries         |
+| **Replication**       | Per-follower lag over time, forwarded write rate, forward round-trip latency                                   |
+| **WAL & Checkpoints** | Upload rate, upload errors, upload duration, checkpoint frequency                                              |
+| **Object Store (S3)** | Op rate by type, error rate, p50/p95/p99 latency                                                               |
 
 ### Prometheus metrics
 
-| Metric | Type | Labels | Description |
-|---|---|---|---|
-| `t4_writes_total` | counter | `op` | Completed write operations |
-| `t4_write_errors_total` | counter | `op` | Write operations that returned an error |
-| `t4_write_duration_seconds` | histogram | `op` | Write latency (WAL + apply) |
-| `t4_forwarded_writes_total` | counter | `op` | Writes forwarded from follower to leader |
-| `t4_forward_duration_seconds` | histogram | `op` | Forwarded write round-trip latency |
-| `t4_current_revision` | gauge | — | Latest applied revision |
-| `t4_compact_revision` | gauge | — | Compaction watermark |
-| `t4_role` | gauge | `role` | 1 for the active role (`leader`/`follower`/`single`) |
-| `t4_wal_uploads_total` | counter | — | WAL segments successfully uploaded |
-| `t4_wal_upload_errors_total` | counter | — | Failed WAL segment uploads |
-| `t4_wal_upload_duration_seconds` | histogram | — | WAL segment upload latency |
-| `t4_wal_gc_segments_total` | counter | — | WAL segments deleted from S3 after checkpointing |
-| `t4_checkpoints_total` | counter | — | Checkpoints written to S3 |
-| `t4_elections_total` | counter | `outcome` | Election attempts (`won`/`lost`) |
-| `t4_follower_resyncs_total` | counter | `reason` | Full resync events triggered on followers (`behind_leader_start` / `ring_buffer_miss` / `stream_gap`) |
-| `t4_auth_attempts_total` | counter | `result` | Authentication attempts (`success` / `fail` / `locked`) |
-| `t4_watch_active` | gauge | — | Currently active watch subscriptions |
-| `t4_watch_active_prefixes` | gauge | — | Distinct prefixes with active watch subscriptions |
-| `t4_watch_scan_duration_seconds` | histogram | — | Time spent scanning revision logs for watch delivery |
-| `t4_watch_scan_revision_span` | histogram | — | Revision span covered by each watch scan |
-| `t4_watch_scan_entries_total` | counter | `result` | Watch scan entries by result (`scanned` / `matched`) |
+| Metric                           | Type      | Labels    | Description                                                                                           |
+|----------------------------------|-----------|-----------|-------------------------------------------------------------------------------------------------------|
+| `t4_writes_total`                | counter   | `op`      | Completed write operations                                                                            |
+| `t4_write_errors_total`          | counter   | `op`      | Write operations that returned an error                                                               |
+| `t4_write_duration_seconds`      | histogram | `op`      | Write latency (WAL + apply)                                                                           |
+| `t4_forwarded_writes_total`      | counter   | `op`      | Writes forwarded from follower to leader                                                              |
+| `t4_forward_duration_seconds`    | histogram | `op`      | Forwarded write round-trip latency                                                                    |
+| `t4_current_revision`            | gauge     | —         | Latest applied revision                                                                               |
+| `t4_compact_revision`            | gauge     | —         | Compaction watermark                                                                                  |
+| `t4_role`                        | gauge     | `role`    | 1 for the active role (`leader`/`follower`/`single`)                                                  |
+| `t4_wal_uploads_total`           | counter   | —         | WAL segments successfully uploaded                                                                    |
+| `t4_wal_upload_errors_total`     | counter   | —         | Failed WAL segment uploads                                                                            |
+| `t4_wal_upload_duration_seconds` | histogram | —         | WAL segment upload latency                                                                            |
+| `t4_wal_gc_segments_total`       | counter   | —         | WAL segments deleted from S3 after checkpointing                                                      |
+| `t4_checkpoints_total`           | counter   | —         | Checkpoints written to S3                                                                             |
+| `t4_elections_total`             | counter   | `outcome` | Election attempts (`won`/`lost`)                                                                      |
+| `t4_follower_resyncs_total`      | counter   | `reason`  | Full resync events triggered on followers (`behind_leader_start` / `ring_buffer_miss` / `stream_gap`) |
+| `t4_auth_attempts_total`         | counter   | `result`  | Authentication attempts (`success` / `fail` / `locked`)                                               |
+| `t4_watch_active`                | gauge     | —         | Currently active watch subscriptions                                                                  |
+| `t4_watch_active_prefixes`       | gauge     | —         | Distinct prefixes with active watch subscriptions                                                     |
+| `t4_watch_scan_duration_seconds` | histogram | —         | Time spent scanning revision logs for watch delivery                                                  |
+| `t4_watch_scan_revision_span`    | histogram | —         | Revision span covered by each watch scan                                                              |
+| `t4_watch_scan_entries_total`    | counter   | `result`  | Watch scan entries by result (`scanned` / `matched`)                                                  |
 
 `op` label values: `put`, `create`, `update`, `delete`, `compact`.
 
@@ -425,47 +457,54 @@ The dashboard contains six sections:
 
 ## Performance
 
-Numbers are from `go test -bench=. -benchtime=5s` on an Apple M4 Pro (12 cores, NVMe SSD). All tests use in-process loopback — no real network or S3.
+Numbers are from `go test -bench=. -benchtime=5s` on an Apple M4 Pro (12 cores, NVMe SSD). All tests use in-process
+loopback — no real network or S3.
 
 ### Single-node (no peers, no S3)
 
-Write latency is dominated by a single WAL fsync (~8 ms on NVMe). Concurrent writers are automatically batched by the `commitLoop` into a single fsync per drain cycle (group commit).
+Write latency is dominated by a single WAL fsync (~8 ms on NVMe). Concurrent writers are automatically batched by the
+`commitLoop` into a single fsync per drain cycle (group commit).
 
-| Operation | Throughput | Latency |
-|---|---|---|
-| `Put` (serial) | ~123 writes/s | 8.1 ms |
-| `Put` (12 concurrent writers) | ~750 writes/s | 1.3 ms avg |
-| `Put` (192 concurrent writers) | ~11,600 writes/s | 86 µs avg |
-| `Get` / `LinearizableGet` (leader) | ~2,300,000 reads/s | 0.43 µs |
-| `List` (100 keys) | ~27,900 ops/s | 36 µs |
+| Operation                          | Throughput         | Latency    |
+|------------------------------------|--------------------|------------|
+| `Put` (serial)                     | ~123 writes/s      | 8.1 ms     |
+| `Put` (12 concurrent writers)      | ~750 writes/s      | 1.3 ms avg |
+| `Put` (192 concurrent writers)     | ~11,600 writes/s   | 86 µs avg  |
+| `Get` / `LinearizableGet` (leader) | ~2,300,000 reads/s | 0.43 µs    |
+| `List` (100 keys)                  | ~27,900 ops/s      | 36 µs      |
 
 ### 3-node cluster (localhost loopback)
 
-Write latency = leader WAL fsync + quorum ACK round-trip (follower WAL fsync + network). On loopback, both nodes share the same SSD so each write costs roughly two sequential fsyncs (~16 ms).
+Write latency = leader WAL fsync + quorum ACK round-trip (follower WAL fsync + network). On loopback, both nodes share
+the same SSD so each write costs roughly two sequential fsyncs (~16 ms).
 
-| Operation | Throughput | Latency |
-|---|---|---|
-| `Put` (serial) | ~43 writes/s | 23 ms |
-| `Put` (12 concurrent writers) | ~224 writes/s | 4.5 ms avg |
-| `LinearizableGet` (follower) | ~18,100 reads/s | 55 µs |
+| Operation                     | Throughput      | Latency    |
+|-------------------------------|-----------------|------------|
+| `Put` (serial)                | ~43 writes/s    | 23 ms      |
+| `Put` (12 concurrent writers) | ~224 writes/s   | 4.5 ms avg |
+| `LinearizableGet` (follower)  | ~18,100 reads/s | 55 µs      |
 
-With group commit, the per-write overhead of the quorum ACK round-trip disappears almost entirely under load — 12 concurrent writers improve from 43 to 224 writes/s by batching many writes into one ACK round.
+With group commit, the per-write overhead of the quorum ACK round-trip disappears almost entirely under load — 12
+concurrent writers improve from 43 to 224 writes/s by batching many writes into one ACK round.
 
 ### Impact of real-world latency
 
 Write latency scales with inter-node RTT and S3 latency (single-node only):
 
-| Scenario | Additional latency | Notes |
-|---|---|---|
-| Cluster, same-host loopback | +15 ms | loopback gRPC + follower fsync |
-| Cluster, LAN (1 ms RTT) | +9 ms | ≈ follower fsync + 2× 0.5 ms network |
-| Cluster, cross-AZ (5 ms RTT) | +18 ms | ≈ follower fsync + 2× 5 ms network |
-| Cluster, cross-region (50 ms RTT) | +108 ms | high-latency links hurt serial throughput most |
-| Single-node, S3 upload | +100–500 ms | sync upload per WAL segment — use cluster mode for low latency |
+| Scenario                          | Additional latency | Notes                                                          |
+|-----------------------------------|--------------------|----------------------------------------------------------------|
+| Cluster, same-host loopback       | +15 ms             | loopback gRPC + follower fsync                                 |
+| Cluster, LAN (1 ms RTT)           | +9 ms              | ≈ follower fsync + 2× 0.5 ms network                           |
+| Cluster, cross-AZ (5 ms RTT)      | +18 ms             | ≈ follower fsync + 2× 5 ms network                             |
+| Cluster, cross-region (50 ms RTT) | +108 ms            | high-latency links hurt serial throughput most                 |
+| Single-node, S3 upload            | +100–500 ms        | sync upload per WAL segment — use cluster mode for low latency |
 
-In cluster mode, **S3 uploads are async** (disaster-recovery only) and add zero latency to the write path. Single-node mode uploads each WAL segment to S3 synchronously; write latency is dominated by S3 round-trip, not local fsync. For low-latency single-node deployments without S3, latency is entirely local disk (~8 ms NVMe).
+In cluster mode, **S3 uploads are async** (disaster-recovery only) and add zero latency to the write path. Single-node
+mode uploads each WAL segment to S3 synchronously; write latency is dominated by S3 round-trip, not local fsync. For
+low-latency single-node deployments without S3, latency is entirely local disk (~8 ms NVMe).
 
-Read latency on a follower includes one `ForwardGetRevision` gRPC call to the leader to obtain the current revision, then a local Pebble lookup. On localhost this costs ~55 µs; on LAN expect ~1–2 ms; on cross-AZ ~10 ms.
+Read latency on a follower includes one `ForwardGetRevision` gRPC call to the leader to obtain the current revision,
+then a local Pebble lookup. On localhost this costs ~55 µs; on LAN expect ~1–2 ms; on cross-AZ ~10 ms.
 
 ---
 
@@ -474,10 +513,13 @@ Read latency on a follower includes one `ForwardGetRevision` gRPC call to the le
 ### What is durable
 
 A write is durable when it has been:
-- fsynced to the leader's WAL **and** ACKed by all connected followers (cluster mode) — the entry exists on at least two nodes' WALs before the caller sees success, **or**
+
+- fsynced to the leader's WAL **and** ACKed by all connected followers (cluster mode) — the entry exists on at least two
+  nodes' WALs before the caller sees success, **or**
 - fsynced to the local WAL **and** the WAL segment has been uploaded to S3 (single-node mode).
 
-In cluster mode S3 is disaster-recovery only (both nodes fail simultaneously). WAL uploads are fully async and do not affect write latency. In single-node mode without S3, durability depends entirely on local disk.
+In cluster mode S3 is disaster-recovery only (both nodes fail simultaneously). WAL uploads are fully async and do not
+affect write latency. In single-node mode without S3, durability depends entirely on local disk.
 
 ### Recovery procedure
 
@@ -494,15 +536,49 @@ Steps 4–5 ensure that no committed write is lost even if the node is killed be
 
 ### S3 unavailability
 
-In cluster mode, S3 uploads are fully async — WAL segments and checkpoints are uploaded in the background without blocking writes. In single-node mode, each WAL segment is uploaded to S3 synchronously before the write is acknowledged. In both modes, on restart local WAL segments are replayed first, so no data written to the local WAL is lost even if it was never uploaded to S3.
+In cluster mode, S3 uploads are fully async — WAL segments and checkpoints are uploaded in the background without
+blocking writes. In single-node mode, each WAL segment is uploaded to S3 synchronously before the write is acknowledged.
+In both modes, on restart local WAL segments are replayed first, so no data written to the local WAL is lost even if it
+was never uploaded to S3.
 
 ---
 
 ## Storage management
 
+### Local database size
+
+As a sizing reference, a local Pebble database with 1,000,000 live keys and 256-byte varied values measured about **317
+MiB on disk after compaction** (roughly **332 bytes per key**). This includes T4's live key index and revision log
+entries. The test used keys like `/size/000000001`, so longer keys add directly to the total.
+
+For the same 256-byte value size:
+
+|   Live keys | Local DB size | Basis        |
+|------------:|--------------:|--------------|
+|   1 million |      ~317 MiB | measured     |
+|  10 million |      ~3.0 GiB | measured     |
+| 100 million |       ~30 GiB | extrapolated |
+|   1 billion |      ~300 GiB | extrapolated |
+
+For 1,000,000 live keys:
+
+| Value size | Local DB size | Bytes per key |
+|-----------:|--------------:|--------------:|
+|       64 B |       ~95 MiB |        ~100 B |
+|      128 B |      ~159 MiB |        ~167 B |
+|      256 B |      ~317 MiB |        ~332 B |
+|      1 KiB |     ~1.04 GiB |      ~1,118 B |
+|      4 KiB |      ~4.0 GiB |      ~4,279 B |
+
+Actual size varies with key length, value compressibility, update/delete history, and Pebble compaction state. S3 stores
+the same logical database as checkpoint SSTs plus retained WAL segments; a single latest checkpoint is usually in the
+same range as the compacted local DB, while total S3 usage depends on checkpoint retention, WAL retention, and
+branch-pinned SSTs.
+
 ### Garbage collection
 
-Old checkpoints and WAL segments accumulate in S3 unless explicitly pruned. Run `t4 gc` periodically (e.g. daily via cron) to reclaim storage:
+Old checkpoints and WAL segments accumulate in S3 unless explicitly pruned. Run `t4 gc` periodically (e.g. daily via
+cron) to reclaim storage:
 
 ```bash
 t4 gc \
@@ -511,7 +587,8 @@ t4 gc \
   --keep 3
 ```
 
-`--keep` (default: 3) sets how many of the most recent checkpoints to retain. The command performs three passes in order:
+`--keep` (default: 3) sets how many of the most recent checkpoints to retain. The command performs three passes in
+order:
 
 1. **Checkpoint GC** — deletes old checkpoint archives beyond the `--keep` window.
 2. **Orphan SST GC** — deletes SST files exclusively referenced by the deleted checkpoints.
@@ -528,7 +605,9 @@ GC complete
 
 #### Branch safety
 
-Before deleting any checkpoint, `t4 gc` reads all active branch registrations. Any checkpoint pinned by an active branch is skipped unconditionally — even if it falls outside the `--keep` window. The SSTs it references are also excluded from orphan deletion.
+Before deleting any checkpoint, `t4 gc` reads all active branch registrations. Any checkpoint pinned by an active branch
+is skipped unconditionally — even if it falls outside the `--keep` window. The SSTs it references are also excluded from
+orphan deletion.
 
 - Call `t4 branch fork` **before** running GC on the source.
 - Call `t4 branch unfork` only after the branch node is fully decommissioned.
@@ -537,7 +616,8 @@ Before deleting any checkpoint, `t4 gc` reads all active branch registrations. A
 
 ## Branching
 
-Branches let you fork a database at any checkpoint with zero S3 data copies. SST files are content-addressed and shared between the source and all branches — no data is duplicated.
+Branches let you fork a database at any checkpoint with zero S3 data copies. SST files are content-addressed and shared
+between the source and all branches — no data is duplicated.
 
 ### Requirements
 
@@ -566,7 +646,8 @@ t4 run \
   --branch-checkpoint checkpoint/0000000001/00000000000000000100/manifest.json
 ```
 
-On first boot the branch node downloads SSTs and Pebble metadata from the source prefix. On subsequent restarts `--branch-checkpoint` is ignored (the local data directory already exists).
+On first boot the branch node downloads SSTs and Pebble metadata from the source prefix. On subsequent restarts
+`--branch-checkpoint` is ignored (the local data directory already exists).
 
 ### Creating a branch (Go library)
 
@@ -580,24 +661,25 @@ branchStore := object.NewS3Store(object.S3Config{Bucket: "my-bucket", Prefix: "t
 // Register and get the checkpoint key.
 cpKey, err := t4.Fork(ctx, sourceStore, "my-branch")
 if err != nil {
-    log.Fatal(err)
+log.Fatal(err)
 }
 
 // Start the branch node.
 node, err := t4.Open(t4.Config{
-    DataDir:       "/var/lib/t4-branch",
-    ObjectStore:   branchStore,
-    AncestorStore: sourceStore,
-    BranchPoint: &t4.BranchPoint{
-        SourceStore:   sourceStore,
-        CheckpointKey: cpKey,
-    },
+DataDir:       "/var/lib/t4-branch",
+ObjectStore:   branchStore,
+AncestorStore: sourceStore,
+BranchPoint: &t4.BranchPoint{
+SourceStore:   sourceStore,
+CheckpointKey: cpKey,
+},
 })
 ```
 
 ### Forking from a specific checkpoint
 
-By default `Fork` uses the latest checkpoint. To fork from an earlier revision, call `checkpoint.RegisterBranch` directly with the specific key:
+By default `Fork` uses the latest checkpoint. To fork from an earlier revision, call `checkpoint.RegisterBranch`
+directly with the specific key:
 
 ```bash
 # CLI
@@ -613,7 +695,7 @@ import "github.com/t4db/t4/internal/checkpoint"
 
 cpKey := "checkpoint/0000000001/00000000000000000050/manifest.json"
 if err := checkpoint.RegisterBranch(ctx, sourceStore, "my-branch", cpKey); err != nil {
-    log.Fatal(err)
+log.Fatal(err)
 }
 
 ### Removing a branch
@@ -629,7 +711,7 @@ t4 branch unfork \
 
 ```go
 if err := t4.Unfork(ctx, sourceStore, "my-branch"); err != nil {
-    log.Fatal(err)
+log.Fatal(err)
 }
 ```
 
@@ -647,9 +729,11 @@ if err := t4.Unfork(ctx, sourceStore, "my-branch"); err != nil {
 
 ## Point-in-time restore (S3 versioning)
 
-> **Note**: this mechanism requires S3 versioning to be enabled on the bucket. For most use cases, [Branching](#branching) is simpler and does not require versioning.
+> **Note**: this mechanism requires S3 versioning to be enabled on the bucket. For most use
+> cases, [Branching](#branching) is simpler and does not require versioning.
 
-`RestorePoint` bootstraps a new node from a specific set of S3 object version IDs captured at a past moment. See [api.md — Point-in-time restore](api.md#point-in-time-restore-s3-versioning) for the Go API.
+`RestorePoint` bootstraps a new node from a specific set of S3 object version IDs captured at a past moment.
+See [api.md — Point-in-time restore](api.md#point-in-time-restore-s3-versioning) for the Go API.
 
 ### Requirements
 


### PR DESCRIPTION
Adds an opt-in storage sizing test for T4’s Pebble store and documents the measured results.

- Adds TestDBSizeMillionKeys, gated by T4_DB_SIZE_TEST=1, with knobs for key count, value size, and batch size.
- Measures on-disk DB size after flush, compaction, and close.
- Updates operations docs and website docs with measured local DB size tables for 1M/10M keys and common value sizes.
- Clarifies how local Pebble size relates to S3 checkpoint/WAL storage.