### PR TITLE
Step down on fatal error

### DIFF
--- a/fault_test.go
+++ b/fault_test.go
@@ -426,6 +426,94 @@ func TestFollowerDoesNotExposeUncommittedEntryAfterLeaderWALError(t *testing.T) 
 	t.Fatalf("new leader exposed uncommitted key after takeover: %v", fmt.Sprintf("%+v", kv))
 }
 
+// TestFollowerTakesOverAfterLeaderFatalWALError verifies that when the leader's
+// commit loop dies because of a fatal WAL error, the leader steps down on its
+// own (cancels the lock-watch goroutine + stops the peer server) so a follower
+// can win election via the standard liveness-TTL path — without the test or
+// an operator calling Close on the dead leader.
+//
+// Without leader-side stepdown the leader becomes a zombie: dead writer, live
+// lock holder. watchLoop keeps refreshing LastSeenNano, every follower
+// TakeOver attempt loses the liveness check, and the cluster stalls until an
+// operator notices and restarts the node. This regression test guards the
+// stepdown path in commitLoop's defer.
+func TestFollowerTakesOverAfterLeaderFatalWALError(t *testing.T) {
+	store := object.NewMem()
+
+	openNode := func(id string) *Node {
+		t.Helper()
+		addr := freeAddrLocal(t)
+		n, err := Open(Config{
+			DataDir:            t.TempDir(),
+			ObjectStore:        store,
+			NodeID:             id,
+			PeerListenAddr:     addr,
+			AdvertisePeerAddr:  addr,
+			FollowerMaxRetries: 2,
+			PeerBufferSize:     1000,
+			CheckpointInterval: 300 * time.Millisecond,
+			SegmentMaxAge:      200 * time.Millisecond,
+		})
+		if err != nil {
+			t.Fatalf("open %s: %v", id, err)
+		}
+		return n
+	}
+
+	a := openNode("node-a")
+	defer func() { _ = a.Close() }()
+	b := openNode("node-b")
+	defer func() { _ = b.Close() }()
+
+	nodes := []*Node{a, b}
+	leader := waitForLeaderNodeLocal(t, nodes, 10*time.Second)
+	var follower *Node
+	for _, n := range nodes {
+		if n != leader {
+			follower = n
+			break
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	seedRev, err := leader.Put(ctx, "/seed", []byte("ok"), 0)
+	if err != nil {
+		t.Fatalf("seed Put: %v", err)
+	}
+	if err := follower.WaitForRevision(ctx, seedRev); err != nil {
+		t.Fatalf("follower seed WaitForRevision: %v", err)
+	}
+
+	// Drive the leader's commit loop into a fatal-exit path. After this Put
+	// returns, the commit loop will have called return; the defer fences
+	// the node and triggers stepDownOnFatalCommitError.
+	fw := newFakeWAL(leader)
+	fw.setFailNow(true)
+	if _, err := leader.Put(ctx, "/ghost", []byte("should-not-commit"), 0); err == nil {
+		t.Fatal("expected injected WAL failure, got nil")
+	}
+	fw.setFailNow(false)
+
+	// Crucial: do NOT call leader.Close(). The follower must be able to
+	// take over solely because the leader stepped down on its own.
+	//
+	// Stepdown stops the lock-watch goroutine, so LastSeenNano stops being
+	// refreshed. After LeaderLivenessTTL (~6s) the lock is stale enough for
+	// the follower's TakeOver liveness check to proceed. Add slack for CI:
+	// allow up to 20s.
+	newLeader := waitForLeaderNodeLocal(t, []*Node{follower}, 20*time.Second)
+	if newLeader != follower {
+		t.Fatalf("expected follower to take over, got %p", newLeader)
+	}
+
+	// The new leader must accept a write.
+	if _, err := newLeader.Put(ctx, "/after-takeover", []byte("ok"), 0); err != nil {
+		t.Fatalf("write after takeover: %v", err)
+	}
+}
+
 func TestFollowerReconnectDropsStagedUncommittedEntries(t *testing.T) {
 	store := object.NewMem()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/leader.go
+++ b/leader.go
@@ -193,6 +193,18 @@ func (n *Node) watchLoop(ctx context.Context, lock *election.Lock, term uint64) 
 	// handlers to finish; those handlers (Put/Create/…) acquire fenceMu.RLock()
 	// themselves, so calling Stop() while holding the write lock would deadlock.
 	fencedCheck := func(reason string, touch bool) bool {
+		// A fenced node (Close in flight, commitLoop dead from a fatal
+		// error, or any future code path that flips n.closed) must NOT
+		// refresh LastSeenNano on the cluster lock. Touching the lock
+		// here would assert "I'm a healthy leader" while in fact this
+		// node can no longer make progress, causing followers' TakeOver
+		// to back off on a liveness check and the cluster to stall.
+		// Exit the watch loop instead; whichever path set n.closed is
+		// responsible for tearing down peerGRPC.
+		if n.closed.Load() {
+			n.log.Debugf("t4: leader watch (%s): node fenced — exiting watch loop", reason)
+			return false
+		}
 		n.fenceMu.Lock()
 		rCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		rec, etag, err := lock.ReadETag(rCtx)
@@ -352,6 +364,14 @@ func (n *Node) HandleForward(ctx context.Context, req *peer.ForwardRequest) (*pe
 // It drains writeC, writes all entries to WAL with a single fsync, applies
 // them to Pebble as a batch, and signals each caller's done channel.
 func (n *Node) commitLoop(ctx context.Context) {
+	// fatalExit is set when commitLoop returns because of a WAL or Pebble
+	// error, as opposed to a clean ctx.Done shutdown. In the fatal case the
+	// leader must step down so it does not hold the cluster lock as a
+	// zombie: dead writer, live lock holder. Without stepdown a follower
+	// cannot win TakeOver (the watchLoop keeps LastSeenNano fresh) and the
+	// cluster stalls until an operator restarts the dead node.
+	var fatalExit bool
+
 	defer func() {
 		// Fence the node first so new writers fail fast.
 		n.closed.Store(true)
@@ -377,6 +397,9 @@ func (n *Node) commitLoop(ctx context.Context) {
 			case req := <-n.writeC:
 				req.done <- ErrClosed
 			default:
+				if fatalExit {
+					n.stepDownOnFatalCommitError()
+				}
 				return
 			}
 		}
@@ -484,9 +507,36 @@ func (n *Node) commitLoop(ctx context.Context) {
 				continue
 			}
 			// A WAL or Pebble error leaves the segment in an unknown state.
-			// Stop accepting writes immediately; the defer will fence the node.
+			// Stop accepting writes immediately; the defer fences the node
+			// and triggers leader stepdown so followers can take over.
+			fatalExit = true
 			return
 		}
+	}
+}
+
+// stepDownOnFatalCommitError releases leadership after the commit loop has
+// exited due to a fatal WAL/Pebble error. Without this, the node remains the
+// cluster's elected leader (watchLoop keeps LastSeenNano fresh, peer server
+// keeps the port bound) even though it can no longer accept writes —
+// followers cannot win TakeOver and the cluster stalls. Stepping down here
+// stops the lock-refresh polling and tears down the peer server so followers
+// notice the failure and proceed to election via the standard liveness-TTL
+// path.
+//
+// Idempotent with respect to Node.Close: cancelBg is a sync.Once-style
+// context cancel, and grpcSrv.Stop is documented as idempotent.
+func (n *Node) stepDownOnFatalCommitError() {
+	if n.loadRole() != roleLeader {
+		return
+	}
+	n.log.Warnf("t4: commit loop exited with fatal error — stepping down so followers can take over")
+	n.cancelBg()
+	n.mu.Lock()
+	grpcSrv := n.peerGRPC
+	n.mu.Unlock()
+	if grpcSrv != nil {
+		grpcSrv.Stop()
 	}
 }
 


### PR DESCRIPTION
Zombie-leader after fatal commit-loop exit. 
Before, a WAL/Pebble error inside commitLoop left the node fenced for writes but still holding the cluster lock — watchLoop kept refreshing LastSeenNano, peer server stayed bound, and follower TakeOver attempts perpetually lost the liveness check. Operator restart required.