### PR TITLE
Various fixes

### DIFF
--- a/follower.go
+++ b/follower.go
@@ -55,13 +55,7 @@ func (n *Node) followLoop(bgCtx context.Context) {
 				// its Open() value and TakeOver backs off because it sees the
 				// current lock term as "already taken over at a higher term".
 				// The last entry in the batch has the highest-or-equal term.
-				if last := entries[len(entries)-1]; last.Term > n.term {
-					n.mu.Lock()
-					if last.Term > n.term {
-						n.term = last.Term
-					}
-					n.mu.Unlock()
-				}
+				n.observeTerm(entries[len(entries)-1].Term)
 				// Advance only after a successful apply so a reconnect retries
 				// from the start of the failed batch rather than skipping it.
 				fromRev = entries[len(entries)-1].Sequence() + 1
@@ -172,6 +166,7 @@ func (n *Node) attemptPromotion(bgCtx context.Context, lock *election.Lock, grac
 			// Back off from election, but do not keep retrying a stale endpoint.
 			// If the lock advertises a leader address, switch followLoop to it.
 			if existing.LeaderAddr != "" {
+				n.observeTerm(existing.Term)
 				return peer.NewClient(existing.LeaderAddr, n.cfg.NodeID, n.cfg.FollowerMaxRetries, n.cfg.PeerClientTLS, n.log), false
 			}
 			return nil, false
@@ -209,13 +204,14 @@ func (n *Node) attemptPromotion(bgCtx context.Context, lock *election.Lock, grac
 			n.log.Infof("t4: takebover: node is behind leader committed rev (ours=%d, leader=%d) — following current leader to catch up",
 				n.db.Load().CurrentRevision(), existing.CommittedRev)
 			if existing.LeaderAddr != "" {
+				n.observeTerm(existing.Term)
 				return peer.NewClient(existing.LeaderAddr, n.cfg.NodeID, n.cfg.FollowerMaxRetries, n.cfg.PeerClientTLS, n.log), false
 			}
 			return nil, false
 		}
 	}
 
-	rec, won, err := lock.TakeOver(ctx, n.term, n.db.Load().CurrentRevision())
+	rec, won, err := lock.TakeOver(ctx, n.currentTerm(), n.db.Load().CurrentRevision())
 	if err != nil {
 		n.log.Errorf("t4: takeover election error: %v", err)
 		return nil, false
@@ -263,6 +259,7 @@ func (n *Node) attemptPromotion(bgCtx context.Context, lock *election.Lock, grac
 	}
 
 	if rec != nil && rec.LeaderAddr != "" {
+		n.observeTerm(rec.Term)
 		n.log.Infof("t4: lost election to %s (term=%d) — following", rec.NodeID, rec.Term)
 		return peer.NewClient(rec.LeaderAddr, n.cfg.NodeID, n.cfg.FollowerMaxRetries, n.cfg.PeerClientTLS, n.log), false
 	}

--- a/node.go
+++ b/node.go
@@ -217,6 +217,20 @@ type Node struct {
 func (n *Node) loadRole() nodeRole   { return nodeRole(n.role.Load()) }
 func (n *Node) storeRole(r nodeRole) { n.role.Store(int32(r)) }
 
+func (n *Node) observeTerm(term uint64) {
+	n.mu.Lock()
+	if term > n.term {
+		n.term = term
+	}
+	n.mu.Unlock()
+}
+
+func (n *Node) currentTerm() uint64 {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.term
+}
+
 // Open creates and starts a Node.
 func Open(cfg Config) (*Node, error) {
 	cfg.setDefaults()
@@ -670,6 +684,7 @@ func (n *Node) electAndStart(bgCtx context.Context) error {
 		return n.becomeLeader(bgCtx, lock, rec)
 	}
 
+	n.observeTerm(rec.Term)
 	n.storeRole(roleFollower)
 	cli := peer.NewClient(rec.LeaderAddr, n.cfg.NodeID, n.cfg.FollowerMaxRetries, n.cfg.PeerClientTLS, n.log)
 	n.peerCli = cli

--- a/tests/integration/failure_test.go
+++ b/tests/integration/failure_test.go
@@ -176,6 +176,38 @@ func openCluster(t *testing.T, count int, store object.Store) []*t4.Node {
 	return nodes
 }
 
+func openElectionTestNode(t *testing.T, store object.Store, nodeID, dataDir string) *t4.Node {
+	t.Helper()
+	peerAddr := freeAddrImpl(t)
+	node, err := t4.Open(t4.Config{
+		DataDir:             dataDir,
+		ObjectStore:         store,
+		NodeID:              nodeID,
+		PeerListenAddr:      peerAddr,
+		AdvertisePeerAddr:   peerAddr,
+		FollowerMaxRetries:  2,
+		PeerBufferSize:      1000,
+		CheckpointInterval:  300 * time.Millisecond,
+		SegmentMaxAge:       200 * time.Millisecond,
+		LeaderWatchInterval: 200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("open %s: %v", nodeID, err)
+	}
+	return node
+}
+
+func findFollower(t *testing.T, nodes []*t4.Node, leader *t4.Node) *t4.Node {
+	t.Helper()
+	for _, node := range nodes {
+		if node != leader {
+			return node
+		}
+	}
+	t.Fatal("no follower found")
+	return nil
+}
+
 func waitForFollowersRevision(t *testing.T, ctx context.Context, nodes []*t4.Node, leader *t4.Node, rev int64, timeout time.Duration, phase string) {
 	t.Helper()
 
@@ -190,6 +222,95 @@ func waitForFollowersRevision(t *testing.T, ctx context.Context, nodes []*t4.Nod
 			t.Fatalf("%s node-%d WaitForRevision(%d): %v (leader_rev=%d node_rev=%d)",
 				phase, i, rev, err, leader.CurrentRevision(), n.CurrentRevision())
 		}
+	}
+}
+
+// ── TestDuplicateNodeIDSupersedesOldNode ─────────────────────────────────────
+
+func TestDuplicateNodeIDSupersedesOldNode(t *testing.T) {
+	store := object.NewMem()
+	first := openElectionTestNode(t, store, "same-node", t.TempDir())
+	defer func() { _ = first.Close() }()
+	waitForLeaderNode(t, []*t4.Node{first}, 10*time.Second)
+
+	second := openElectionTestNode(t, store, "same-node", t.TempDir())
+	defer func() { _ = second.Close() }()
+	waitForLeaderNode(t, []*t4.Node{second}, 10*time.Second)
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		_, err := first.LinearizableGet(ctx, "/duplicate-node/probe")
+		cancel()
+		if errors.Is(err, t4.ErrClosed) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("original node did not report ErrClosed after duplicate node-id superseded its lock")
+}
+
+// ── TestFollowerTakesOverWithoutUserWrites ───────────────────────────────────
+
+func TestFollowerTakesOverWithoutUserWrites(t *testing.T) {
+	store := object.NewMem()
+	nodes := []*t4.Node{
+		openElectionTestNode(t, store, "node-a", t.TempDir()),
+		openElectionTestNode(t, store, "node-b", t.TempDir()),
+	}
+	for _, node := range nodes {
+		defer func() { _ = node.Close() }()
+	}
+
+	leader := waitForLeaderNode(t, nodes, 10*time.Second)
+	follower := findFollower(t, nodes, leader)
+	_ = leader.Close()
+
+	if newLeader := waitForLeaderNode(t, []*t4.Node{follower}, 30*time.Second); newLeader != follower {
+		t.Fatalf("expected follower to take over, got %p", newLeader)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := follower.Put(ctx, "/failover/no-writes", []byte("ok"), 0); err != nil {
+		t.Fatalf("write after no-write takeover: %v", err)
+	}
+}
+
+// ── TestPreviousFollowerStartsAloneWithoutPreviousLeader ─────────────────────
+
+func TestPreviousFollowerStartsAloneWithoutPreviousLeader(t *testing.T) {
+	store := object.NewMem()
+	leaderDir := t.TempDir()
+	followerDir := t.TempDir()
+	nodes := []*t4.Node{
+		openElectionTestNode(t, store, "node-a", leaderDir),
+		openElectionTestNode(t, store, "node-b", followerDir),
+	}
+
+	leader := waitForLeaderNode(t, nodes, 10*time.Second)
+	follower := findFollower(t, nodes, leader)
+	followerID, restartDir := "node-a", leaderDir
+	if follower == nodes[1] {
+		followerID, restartDir = "node-b", followerDir
+	}
+	if err := follower.Close(); err != nil {
+		t.Fatalf("close follower: %v", err)
+	}
+	if err := leader.Close(); err != nil {
+		t.Fatalf("close leader: %v", err)
+	}
+
+	restarted := openElectionTestNode(t, store, followerID, restartDir)
+	defer func() { _ = restarted.Close() }()
+	if newLeader := waitForLeaderNode(t, []*t4.Node{restarted}, 30*time.Second); newLeader != restarted {
+		t.Fatalf("expected restarted former follower to take over, got %p", newLeader)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := restarted.Put(ctx, "/restart/former-follower", []byte("ok"), 0); err != nil {
+		t.Fatalf("write after former follower restart: %v", err)
 	}
 }
 


### PR DESCRIPTION
- Followers now record the leader term from the election record when they lose initial election and start following.
- Takeover uses a locked currentTerm()
- Tests added