### PR TITLE
bench: make value size configurable via BENCH_VAL_SIZE

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -40,6 +40,17 @@ Tune ops count and concurrency with environment variables:
 BENCH_TOTAL=10000 BENCH_CLIENTS=8 ./bench/run.sh single
 ```
 
+Value size defaults to 256 bytes, which is well below a real workload. A
+Kubernetes object is several KiB, and payload size changes the answer: the
+write path is bytes-bound before it is operations-bound, so a benchmark at 256
+bytes measures per-operation overhead rather than the throughput ceiling an
+actual control plane would hit.
+
+```bash
+# Kubernetes-sized objects
+BENCH_VAL_SIZE=4096 BENCH_CLIENTS=256 ./bench/run.sh single-s3
+```
+
 ## Workloads
 
 | Workload | Description | Key insight |

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -10,6 +10,7 @@
 # Environment overrides:
 #   BENCH_TOTAL    total ops per workload (default: 50000)
 #   BENCH_CLIENTS  concurrent clients     (default: 16)
+#   BENCH_VAL_SIZE value size in bytes    (default: 256)
 #   BENCH_WORKLOADS space-separated list  (default: all six)
 set -euo pipefail
 
@@ -20,6 +21,7 @@ mkdir -p "$RESULTS_DIR"
 
 TOTAL="${BENCH_TOTAL:-50000}"
 CLIENTS="${BENCH_CLIENTS:-16}"
+VALSIZE="${BENCH_VAL_SIZE:-256}"
 WORKLOADS="${BENCH_WORKLOADS:-seq-put par-put seq-get par-get mixed watch}"
 JSONL="$RESULTS_DIR/results.jsonl"
 
@@ -70,6 +72,7 @@ run_workloads() {
             --endpoints "$endpoints" \
             --workload   "$wl" \
             --clients    "$CLIENTS" \
+            --val-size   "$VALSIZE" \
             --total      "$TOTAL" \
             --scenario   "$scenario" \
             --system     "$system" \


### PR DESCRIPTION
The harness hardcoded t4bench's 256-byte default, so it could not vary the one parameter that most changes the result. A Kubernetes object is several KiB, and the write path saturates on bytes before operations: measured at 256 bytes a single writer looked like ~18k writes/sec, but at 4 KiB the same setup ceilings at less than half that. Benchmarking only at 256 bytes measures per-operation overhead and misses the ceiling a real control plane meets.